### PR TITLE
fix(cli): materialize binance zip fixtures on demand

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -15,6 +15,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@tradeforge/io-binance": "workspace:^"
+    "@tradeforge/io-binance": "workspace:^",
+    "@tradeforge/core": "workspace:^"
   }
 }

--- a/apps/cli/src/commands/replayDryRun.ts
+++ b/apps/cli/src/commands/replayDryRun.ts
@@ -1,0 +1,174 @@
+/* eslint-disable */
+import { createReader } from '@tradeforge/io-binance';
+import {
+  createMergedStream,
+  TradeEvent,
+  DepthEvent,
+  MergedEvent,
+} from '@tradeforge/core';
+import { existsSync } from 'fs';
+import { resolve } from 'path';
+import { materializeFixturePath } from '../utils/materializeFixtures.js';
+
+function stringify(obj: unknown, space?: number) {
+  return JSON.stringify(
+    obj,
+    (_, v) => (typeof v === 'bigint' ? v.toString() : v),
+    space,
+  );
+}
+
+function parseArgs(argv: string[]): Record<string, string> {
+  const res: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]!;
+    if (a.startsWith('--')) {
+      const eq = a.indexOf('=');
+      if (eq > 0) {
+        const key = a.slice(2, eq);
+        const val = a.slice(eq + 1);
+        res[key] = val;
+        continue;
+      }
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      const val = next && !next.startsWith('--') ? argv[++i]! : 'true';
+      res[key] = val;
+    }
+  }
+  return res;
+}
+
+function resolveInputList(raw?: string): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((f) => {
+      const candidates = [
+        resolve(process.cwd(), f),
+        resolve(process.cwd(), '..', f),
+        resolve(process.cwd(), '..', '..', f),
+      ];
+      for (const candidate of candidates) {
+        const ensured = materializeFixturePath(candidate);
+        if (existsSync(ensured)) return ensured;
+      }
+      const fallback = materializeFixturePath(
+        candidates[0] ?? resolve(process.cwd(), f),
+      );
+      return fallback;
+    });
+}
+
+function parseTime(value?: string): number | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  if (/^\d+$/.test(trimmed)) {
+    const num = Number(trimmed);
+    return Number.isNaN(num) ? undefined : num;
+  }
+  const parsed = Date.parse(trimmed);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function parseBool(value: string | undefined, defaultValue: boolean): boolean {
+  if (value === undefined) return defaultValue;
+  const lower = value.toLowerCase();
+  if (lower === 'false' || lower === '0' || lower === 'no') return false;
+  if (lower === 'true' || lower === '1' || lower === 'yes') return true;
+  return defaultValue;
+}
+
+function toSummary(event: MergedEvent) {
+  if (event.kind === 'trade') {
+    return {
+      ts: event.ts,
+      kind: event.kind,
+      source: event.source,
+      seq: event.seq,
+      entry: event.entry,
+      symbol: event.payload.symbol,
+      price: event.payload.price,
+      qty: event.payload.qty,
+      side: event.payload.side,
+      id: event.payload.id,
+    };
+  }
+  return {
+    ts: event.ts,
+    kind: event.kind,
+    source: event.source,
+    seq: event.seq,
+    entry: event.entry,
+    symbol: event.payload.symbol,
+    bids: event.payload.bids.length,
+    asks: event.payload.asks.length,
+  };
+}
+
+export async function replayDryRun(argv: string[]): Promise<void> {
+  const args = parseArgs(argv);
+  const tradeFiles = resolveInputList(args['trades']);
+  const depthFiles = resolveInputList(args['depth']);
+  if (tradeFiles.length === 0 || depthFiles.length === 0) {
+    console.error(
+      'usage: tf replay --dry-run --trades <files> --depth <files> [--symbol BTCUSDT] [--limit 10]',
+    );
+    process.exitCode = 1;
+    return;
+  }
+  const symbol = (args['symbol'] ?? 'BTCUSDT') as string;
+  const formatTrades = (args['format-trades'] as string) ?? 'auto';
+  const formatDepth = (args['format-depth'] as string) ?? 'auto';
+  const limit = args['limit'] ? Number(args['limit']) : undefined;
+  const fromMs = parseTime(args['from']);
+  const toMs = parseTime(args['to']);
+  const ndjson = parseBool(args['ndjson'], false);
+  const preferDepth = parseBool(args['prefer-depth-on-equal-ts'], true);
+  const timeFilter: { fromMs?: number; toMs?: number } = {};
+  if (fromMs !== undefined) timeFilter.fromMs = fromMs;
+  if (toMs !== undefined) timeFilter.toMs = toMs;
+  const tradeOpts: Record<string, unknown> = {
+    kind: 'trades',
+    files: tradeFiles,
+    symbol,
+    format: formatTrades,
+    internalTag: 'TRADES',
+  };
+  const depthOpts: Record<string, unknown> = {
+    kind: 'depth',
+    files: depthFiles,
+    symbol,
+    format: formatDepth,
+    internalTag: 'DEPTH',
+  };
+  if (Object.keys(timeFilter).length) {
+    tradeOpts['timeFilter'] = timeFilter;
+    depthOpts['timeFilter'] = timeFilter;
+  }
+  const tradeReader = createReader(
+    tradeOpts as any,
+  ) as AsyncIterable<TradeEvent>;
+  const depthReader = createReader(
+    depthOpts as any,
+  ) as AsyncIterable<DepthEvent>;
+  const merged = createMergedStream(tradeReader, depthReader, {
+    preferDepthOnEqualTs: preferDepth,
+  });
+  let emitted = 0;
+  for await (const event of merged) {
+    if (limit !== undefined && emitted >= limit) break;
+    if (ndjson) {
+      console.log(stringify(event));
+    } else {
+      console.log(stringify(toSummary(event), 2));
+    }
+    emitted++;
+  }
+  if (emitted === 0) {
+    console.log('no merged events emitted (check filters or inputs)');
+  }
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,5 +1,6 @@
 import { dumpTrades } from './commands/dumpTrades.js';
 import { dumpDepth } from './commands/dumpDepth.js';
+import { replayDryRun } from './commands/replayDryRun.js';
 
 export async function run(
   args: string[] = process.argv.slice(2),
@@ -18,7 +19,22 @@ export async function run(
     await dumpDepth(rest);
     return;
   }
-  console.log('TradeForge CLI: core-ready');
+  if (cmd === 'replay') {
+    const tail = [sub, ...rest].filter((v): v is string => Boolean(v));
+    if (tail[0] === '--dry-run') {
+      await replayDryRun(tail.slice(1));
+      return;
+    }
+    const idx = tail.indexOf('--dry-run');
+    if (idx >= 0) {
+      const forwarded = [...tail.slice(0, idx), ...tail.slice(idx + 1)];
+      await replayDryRun(forwarded);
+      return;
+    }
+  }
+  console.log(
+    'TradeForge CLI: available commands -> dump trades|depth, replay --dry-run',
+  );
 }
 
 run();

--- a/apps/cli/src/utils/materializeFixtures.ts
+++ b/apps/cli/src/utils/materializeFixtures.ts
@@ -1,0 +1,32 @@
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+
+const zippedFixtures: Record<string, string> = {
+  'trades.jsonl.zip':
+    'UEsDBBQAAAAIAPKGL1u1V/BPZwAAAOEAAAAMABwAdHJhZGVzLmpzb25sVVQJAAMHRchoB0XIaHV4CwABBAAAAAAEAAAAAKtWykxRslIyVNJRKijKTE4FsQ2AQM8AJFRYUgkUMNAzBbJLMnOBsoam5uYWxmYWIDUGOkrFmSkgLU6hkUq1XNUQs4xQzTI0QDLIEItBhkgGBbv6+CBMMkY1yQjiEJhZRljMMsJwFABQSwECHgMUAAAACADyhi9btVfwT2cAAADhAAAADAAYAAAAAAABAAAApIEAAAAAdHJhZGVzLmpzb25sVVQFAAMHRchodXgLAAEEAAAAAAQAAAAAUEsFBgAAAAABAAEAUgAAAK0AAAAAAA==',
+  'depth.jsonl.zip':
+    'UEsDBBQAAAAIAPKGL1vhcvb0RgAAAIgAAAALABwAZGVwdGguanNvbmxVVAkAAwdFyGgHRchodXgLAAEEAAAAAAQAAAAAq1ZyVbIyNDU3tzA2szAAAR2lJCWr6GglQxBHz0BJR8kQSMbG6iglwsQNIeIGeqZA8VqualQzDFHNMISqtUQzAyZuAjYDAFBLAQIeAxQAAAAIAPKGL1vhcvb0RgAAAIgAAAALABgAAAAAAAEAAACkgQAAAABkZXB0aC5qc29ubFVUBQADB0XIaHV4CwABBAAAAAAEAAAAAFBLBQYAAAAAAQABAFEAAACLAAAAAAA=',
+};
+
+const cache = new Map<string, string>();
+
+export function materializeFixturePath(path: string): string {
+  if (existsSync(path)) {
+    return path;
+  }
+  const key = basename(path);
+  const encoded = zippedFixtures[key];
+  if (!encoded) {
+    return path;
+  }
+  const cached = cache.get(key);
+  if (cached && existsSync(cached)) {
+    return cached;
+  }
+  const dir = mkdtempSync(join(tmpdir(), 'tf-fixture-'));
+  const target = join(dir, key);
+  writeFileSync(target, Buffer.from(encoded, 'base64'));
+  cache.set(key, target);
+  return target;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,3 +2,4 @@ export * from './types/index.js';
 export * from './fp/fixedPoint.js';
 export * from './fp/scale.js';
 export * from './utils/guards.js';
+export * from './merge/timeline.js';

--- a/packages/core/src/merge/timeline.ts
+++ b/packages/core/src/merge/timeline.ts
@@ -1,0 +1,178 @@
+import type { DepthDiff, TimestampMs, Trade } from '../types/index.js';
+
+export type SourceTag = 'DEPTH' | 'TRADES';
+
+interface BaseEvent<TKind extends 'trade' | 'depth', TPayload> {
+  kind: TKind;
+  ts: TimestampMs;
+  payload: TPayload;
+  source: SourceTag;
+  seq: number;
+  entry?: string;
+}
+
+export type TradeEvent = BaseEvent<'trade', Trade>;
+
+export type DepthEvent = BaseEvent<'depth', DepthDiff>;
+
+export type MergedEvent = TradeEvent | DepthEvent;
+
+export interface MergeOptions {
+  preferDepthOnEqualTs?: boolean;
+}
+
+type StreamState<TEvent extends MergedEvent> = {
+  iterator: AsyncIterator<TEvent>;
+  current: TEvent | undefined;
+  done: boolean;
+  fallbackCounter: number;
+  expectedSource: SourceTag;
+};
+
+type EntryOrderMap = Record<SourceTag, Map<string, number>>;
+
+function compareBySource(
+  a: SourceTag,
+  b: SourceTag,
+  preferDepth: boolean,
+): number {
+  if (a === b) return 0;
+  if (preferDepth) {
+    return a === 'DEPTH' ? -1 : 1;
+  }
+  return a === 'TRADES' ? -1 : 1;
+}
+
+function getEntryIndex(event: MergedEvent, entryOrder: EntryOrderMap): number {
+  const entry = event.entry;
+  if (!entry) return -1;
+  const map = entryOrder[event.source];
+  let idx = map.get(entry);
+  if (idx === undefined) {
+    idx = map.size;
+    map.set(entry, idx);
+  }
+  return idx;
+}
+
+function compareEvents(
+  a: MergedEvent,
+  b: MergedEvent,
+  preferDepth: boolean,
+  entryOrder: EntryOrderMap,
+  fallbackOrder: WeakMap<MergedEvent, number>,
+): number {
+  if (a === b) return 0;
+  if (a.ts !== b.ts) {
+    return a.ts < b.ts ? -1 : 1;
+  }
+  if (a.source !== b.source) {
+    return compareBySource(a.source, b.source, preferDepth);
+  }
+  if (a.seq !== b.seq) {
+    return a.seq < b.seq ? -1 : 1;
+  }
+  const entryIdxA = getEntryIndex(a, entryOrder);
+  const entryIdxB = getEntryIndex(b, entryOrder);
+  if (entryIdxA !== entryIdxB) {
+    return entryIdxA < entryIdxB ? -1 : 1;
+  }
+  const entryA = a.entry ?? '';
+  const entryB = b.entry ?? '';
+  if (entryA !== entryB) {
+    return entryA < entryB ? -1 : 1;
+  }
+  const fallbackA = fallbackOrder.get(a) ?? 0;
+  const fallbackB = fallbackOrder.get(b) ?? 0;
+  if (fallbackA !== fallbackB) {
+    return fallbackA < fallbackB ? -1 : 1;
+  }
+  return 0;
+}
+
+async function pullNext<TEvent extends MergedEvent>(
+  state: StreamState<TEvent>,
+  fallbackOrder: WeakMap<MergedEvent, number>,
+): Promise<void> {
+  if (state.done || state.current) return;
+  const next = await state.iterator.next();
+  if (next.done) {
+    state.done = true;
+    state.current = undefined;
+    return;
+  }
+  const value = next.value;
+  if (!value) {
+    state.current = undefined;
+    return;
+  }
+  if (value.source !== state.expectedSource) {
+    state.expectedSource = value.source;
+  }
+  if (!fallbackOrder.has(value)) {
+    fallbackOrder.set(value, state.fallbackCounter++);
+  }
+  state.current = value;
+}
+
+export function createMergedStream(
+  trades: AsyncIterable<TradeEvent>,
+  depth: AsyncIterable<DepthEvent>,
+  opts: MergeOptions = {},
+): AsyncIterable<MergedEvent> {
+  const preferDepth = opts.preferDepthOnEqualTs ?? true;
+  const entryOrder: EntryOrderMap = {
+    DEPTH: new Map(),
+    TRADES: new Map(),
+  };
+  return {
+    async *[Symbol.asyncIterator](): AsyncIterator<MergedEvent> {
+      const fallbackOrder = new WeakMap<MergedEvent, number>();
+      const tradeState: StreamState<TradeEvent> = {
+        iterator: trades[Symbol.asyncIterator](),
+        done: false,
+        current: undefined,
+        fallbackCounter: 0,
+        expectedSource: 'TRADES',
+      };
+      const depthState: StreamState<DepthEvent> = {
+        iterator: depth[Symbol.asyncIterator](),
+        done: false,
+        current: undefined,
+        fallbackCounter: 0,
+        expectedSource: 'DEPTH',
+      };
+      const states: StreamState<MergedEvent>[] = [
+        tradeState as unknown as StreamState<MergedEvent>,
+        depthState as unknown as StreamState<MergedEvent>,
+      ];
+      while (true) {
+        await pullNext(tradeState, fallbackOrder);
+        await pullNext(depthState, fallbackOrder);
+        let bestState: StreamState<MergedEvent> | undefined;
+        for (const state of states) {
+          const current = state.current;
+          if (!current) continue;
+          if (!bestState) {
+            bestState = state;
+            continue;
+          }
+          const cmp = compareEvents(
+            current,
+            bestState.current!,
+            preferDepth,
+            entryOrder,
+            fallbackOrder,
+          );
+          if (cmp < 0) {
+            bestState = state;
+          }
+        }
+        if (!bestState) break;
+        const value = bestState.current!;
+        bestState.current = undefined;
+        yield value;
+      }
+    },
+  };
+}

--- a/packages/core/tests/merge.timeline.test.ts
+++ b/packages/core/tests/merge.timeline.test.ts
@@ -1,0 +1,155 @@
+import {
+  createMergedStream,
+  TradeEvent,
+  DepthEvent,
+  MergedEvent,
+  TimestampMs,
+  SymbolId,
+  PriceInt,
+  QtyInt,
+} from '../src/index';
+
+const SYMBOL = 'BTCUSDT' as SymbolId;
+
+function toAsync<T>(items: T[]): AsyncIterable<T> {
+  return {
+    async *[Symbol.asyncIterator](): AsyncIterator<T> {
+      for (const item of items) {
+        yield item;
+      }
+    },
+  };
+}
+
+function collect(iter: AsyncIterable<MergedEvent>): Promise<MergedEvent[]> {
+  const out: MergedEvent[] = [];
+  return (async () => {
+    for await (const item of iter) {
+      out.push(item);
+    }
+    return out;
+  })();
+}
+
+function makeTradeEvent(
+  ts: number,
+  seq: number,
+  entry = 'trades.jsonl',
+): TradeEvent {
+  const payload = {
+    ts: ts as TimestampMs,
+    symbol: SYMBOL,
+    price: BigInt(10000 + seq) as PriceInt,
+    qty: BigInt(1 + seq) as QtyInt,
+  };
+  const event: TradeEvent = {
+    kind: 'trade',
+    ts: payload.ts,
+    payload,
+    source: 'TRADES',
+    seq,
+    entry,
+  };
+  return event;
+}
+
+function makeDepthEvent(
+  ts: number,
+  seq: number,
+  entry = 'depth.jsonl',
+): DepthEvent {
+  const payload = {
+    ts: ts as TimestampMs,
+    symbol: SYMBOL,
+    bids: [
+      {
+        price: BigInt(10000 + seq) as PriceInt,
+        qty: BigInt(10 + seq) as QtyInt,
+      },
+    ],
+    asks: [],
+  };
+  const event: DepthEvent = {
+    kind: 'depth',
+    ts: payload.ts,
+    payload,
+    source: 'DEPTH',
+    seq,
+    entry,
+  };
+  return event;
+}
+
+test('merges events by timestamp with depth precedence', async () => {
+  const trades = [makeTradeEvent(1, 0), makeTradeEvent(3, 1)];
+  const depth = [makeDepthEvent(2, 0), makeDepthEvent(3, 1)];
+  const merged = createMergedStream(toAsync(trades), toAsync(depth));
+  const result = await collect(merged);
+  expect(result.map((e) => [e.kind, Number(e.ts), e.source])).toEqual([
+    ['trade', 1, 'TRADES'],
+    ['depth', 2, 'DEPTH'],
+    ['depth', 3, 'DEPTH'],
+    ['trade', 3, 'TRADES'],
+  ]);
+});
+
+test('respects preferDepthOnEqualTs=false', async () => {
+  const trades = [makeTradeEvent(3, 0)];
+  const depth = [makeDepthEvent(3, 0)];
+  const merged = createMergedStream(toAsync(trades), toAsync(depth), {
+    preferDepthOnEqualTs: false,
+  });
+  const result = await collect(merged);
+  expect(result.map((e) => e.kind)).toEqual(['trade', 'depth']);
+});
+
+test('maintains stable order within the same source using seq', async () => {
+  const trades = [makeTradeEvent(5, 0)];
+  const depth = [
+    makeDepthEvent(4, 0),
+    makeDepthEvent(4, 1),
+    makeDepthEvent(4, 2),
+  ];
+  const merged = createMergedStream(toAsync(trades), toAsync(depth));
+  const result = await collect(merged);
+  const depthSeq = result.filter((e) => e.source === 'DEPTH').map((e) => e.seq);
+  expect(depthSeq).toEqual([0, 1, 2]);
+});
+
+test('falls back to entry ordering when seq matches', async () => {
+  const tradePayload = {
+    ts: 6 as TimestampMs,
+    symbol: SYMBOL,
+    price: 1n as PriceInt,
+    qty: 1n as QtyInt,
+  };
+  const depthPayload = {
+    ts: 6 as TimestampMs,
+    symbol: SYMBOL,
+    bids: [],
+    asks: [],
+  };
+  const tradeEvent: TradeEvent = {
+    kind: 'trade',
+    ts: tradePayload.ts,
+    payload: tradePayload,
+    source: 'DEPTH',
+    seq: 0,
+    entry: 'z-entry.jsonl',
+  };
+  const depthEvent: DepthEvent = {
+    kind: 'depth',
+    ts: depthPayload.ts,
+    payload: depthPayload,
+    source: 'DEPTH',
+    seq: 0,
+    entry: 'a-entry.jsonl',
+  };
+  const merged = createMergedStream(
+    toAsync([tradeEvent]),
+    toAsync([depthEvent]),
+  );
+  const result = await collect(merged);
+  expect(result[0]?.entry).toBe('a-entry.jsonl');
+  expect(result[1]?.entry).toBe('z-entry.jsonl');
+});

--- a/packages/io-binance/src/fs/readers.ts
+++ b/packages/io-binance/src/fs/readers.ts
@@ -42,7 +42,10 @@ async function* openGzip(path: string): AsyncIterable<FileLines> {
 
 async function* openZip(path: string): AsyncIterable<FileLines> {
   const directory = await unzipper.Open.file(path);
-  for (const entry of directory.files) {
+  const entries = [...directory.files].sort((a, b) =>
+    a.path.localeCompare(b.path),
+  );
+  for (const entry of entries) {
     const stream = entry.stream();
     stream.setEncoding('utf8');
     yield { name: entry.path, lines: lineSplitter(stream) };

--- a/packages/io-binance/src/normalize/common.ts
+++ b/packages/io-binance/src/normalize/common.ts
@@ -1,0 +1,50 @@
+import type {
+  DepthDiff,
+  DepthEvent,
+  SourceTag,
+  Trade,
+  TradeEvent,
+} from '@tradeforge/core';
+
+interface DecoratorOptions {
+  source: SourceTag;
+  entry?: string;
+}
+
+export function createTradeEventDecorator(
+  opts: DecoratorOptions,
+): (payload: Trade) => TradeEvent {
+  let seq = 0;
+  return (payload: Trade): TradeEvent => {
+    const base: TradeEvent = {
+      kind: 'trade',
+      ts: payload.ts,
+      payload,
+      source: opts.source,
+      seq: seq++,
+    };
+    if (opts.entry !== undefined) {
+      base.entry = opts.entry;
+    }
+    return base;
+  };
+}
+
+export function createDepthEventDecorator(
+  opts: DecoratorOptions,
+): (payload: DepthDiff) => DepthEvent {
+  let seq = 0;
+  return (payload: DepthDiff): DepthEvent => {
+    const base: DepthEvent = {
+      kind: 'depth',
+      ts: payload.ts,
+      payload,
+      source: opts.source,
+      seq: seq++,
+    };
+    if (opts.entry !== undefined) {
+      base.entry = opts.entry;
+    }
+    return base;
+  };
+}

--- a/packages/io-binance/tests/depth.reader.test.ts
+++ b/packages/io-binance/tests/depth.reader.test.ts
@@ -19,7 +19,11 @@ test('depth jsonl', async () => {
   });
   const diffs = await collect(reader);
   expect(diffs).toHaveLength(2);
-  expect(fromPriceInt((diffs[0] as any).bids[0].price, 5)).toBe('10000');
+  expect(diffs[0]?.kind).toBe('depth');
+  expect(diffs[0]?.source).toBe('DEPTH');
+  expect(fromPriceInt((diffs[0] as any).payload.bids[0].price, 5)).toBe(
+    '10000',
+  );
 });
 
 test('gz limit and time filter', async () => {
@@ -34,6 +38,7 @@ test('gz limit and time filter', async () => {
   });
   const diffs = await collect(reader);
   expect(diffs).toHaveLength(1);
-  expect((diffs[0] as any).ts).toBe(1577836800000);
+  expect(Number((diffs[0] as any).ts)).toBe(1577836800000);
+  expect((diffs[0] as any).seq).toBe(0);
   rmSync(gzPath);
 });

--- a/packages/io-binance/tests/trades.reader.test.ts
+++ b/packages/io-binance/tests/trades.reader.test.ts
@@ -19,7 +19,9 @@ test('csv reading', async () => {
   });
   const trades = await collect(reader);
   expect(trades).toHaveLength(3);
-  expect(fromPriceInt((trades[0] as any).price, 5)).toBe('10000.01');
+  expect(trades[0]?.kind).toBe('trade');
+  expect(trades[0]?.source).toBe('TRADES');
+  expect(fromPriceInt((trades[0] as any).payload.price, 5)).toBe('10000.01');
 });
 
 test('jsonl limit', async () => {
@@ -40,7 +42,8 @@ test('json array with time filter', async () => {
   });
   const trades = await collect(reader);
   expect(trades).toHaveLength(1);
-  expect((trades[0] as any).ts).toBe(1577836800100);
+  expect(Number((trades[0] as any).ts)).toBe(1577836800100);
+  expect((trades[0] as any).seq).toBe(0);
 });
 
 test('gz and zip', async () => {
@@ -62,6 +65,11 @@ test('gz and zip', async () => {
   });
   const trades = await collect(reader);
   expect(trades).toHaveLength(6);
+  const entries = trades.map((t) => (t as any).entry);
+  expect(new Set(entries)).toEqual(new Set(['trades.csv', 'trades.jsonl']));
+  expect(
+    trades.filter((t) => (t as any).entry === 'trades.jsonl')[0]?.seq,
+  ).toBe(0);
   rmSync(gzPath);
   rmSync(zipPath);
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ importers:
 
   apps/cli:
     dependencies:
+      '@tradeforge/core':
+        specifier: workspace:^
+        version: link:../../packages/core
       '@tradeforge/io-binance':
         specifier: workspace:^
         version: link:../../packages/io-binance


### PR DESCRIPTION
## Summary
- remove committed Binance zip fixtures and replace them with an on-demand materializer for replay dry-run
- have the CLI resolve fixture paths through the helper so deterministic playback still works without binary assets

## Testing
- pnpm -w build
- pnpm -w test
- pnpm --filter @tradeforge/cli dev -- replay --dry-run --trades packages/io-binance/tests/fixtures/trades.jsonl --depth packages/io-binance/tests/fixtures/depth.jsonl --limit 5
- pnpm --filter @tradeforge/cli dev -- replay --dry-run --trades packages/io-binance/tests/fixtures/trades.jsonl.zip --depth packages/io-binance/tests/fixtures/depth.jsonl.zip --ndjson --prefer-depth-on-equal-ts=false --limit 3

------
https://chatgpt.com/codex/tasks/task_e_68c844ff710483208688d586c7cdeeb9