### PR TITLE
feat(core,cli): conservative execution on historical TRADES (partial fills, balances, maker fees) + `tf simulate`

### DIFF
--- a/apps/cli/src/commands/simulate.ts
+++ b/apps/cli/src/commands/simulate.ts
@@ -1,0 +1,310 @@
+/* eslint-disable */
+import { createReader } from '@tradeforge/io-binance';
+import {
+  AccountsService,
+  ExchangeState,
+  OrdersService,
+  StaticMockOrderbook,
+  createMergedStream,
+  executeTimeline,
+  toPriceInt,
+  toQtyInt,
+  type DepthEvent,
+  type ExecutionReport,
+  type Order,
+  type SymbolId,
+  type TradeEvent,
+} from '@tradeforge/core';
+import { existsSync } from 'fs';
+import { resolve } from 'path';
+import { materializeFixturePath } from '../utils/materializeFixtures.js';
+
+function stringify(value: unknown, space?: number) {
+  return JSON.stringify(
+    value,
+    (_, v) => (typeof v === 'bigint' ? v.toString() : v),
+    space,
+  );
+}
+
+function parseArgs(argv: string[]): Record<string, string> {
+  const res: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]!;
+    if (a.startsWith('--')) {
+      const eq = a.indexOf('=');
+      if (eq > 0) {
+        const key = a.slice(2, eq);
+        const val = a.slice(eq + 1);
+        res[key] = val;
+        continue;
+      }
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      const val = next && !next.startsWith('--') ? argv[++i]! : 'true';
+      res[key] = val;
+    }
+  }
+  return res;
+}
+
+function resolveInputList(raw?: string): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((f) => {
+      const candidates = [
+        resolve(process.cwd(), f),
+        resolve(process.cwd(), '..', f),
+        resolve(process.cwd(), '..', '..', f),
+      ];
+      for (const candidate of candidates) {
+        const ensured = materializeFixturePath(candidate);
+        if (existsSync(ensured)) return ensured;
+      }
+      const fallback = materializeFixturePath(
+        candidates[0] ?? resolve(process.cwd(), f),
+      );
+      return fallback;
+    });
+}
+
+function parseTime(value?: string): number | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  if (/^\d+$/.test(trimmed)) {
+    const num = Number(trimmed);
+    return Number.isNaN(num) ? undefined : num;
+  }
+  const parsed = Date.parse(trimmed);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function parseBool(value: string | undefined, defaultValue: boolean): boolean {
+  if (value === undefined) return defaultValue;
+  const lower = value.toLowerCase();
+  if (lower === 'false' || lower === '0' || lower === 'no') return false;
+  if (lower === 'true' || lower === '1' || lower === 'yes') return true;
+  return defaultValue;
+}
+
+function createEmptyStream(): AsyncIterable<DepthEvent> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      return;
+    },
+  };
+}
+
+function setupState(symbol: SymbolId) {
+  const priceScale = 5;
+  const qtyScale = 6;
+  const state = new ExchangeState({
+    symbols: {
+      [symbol as unknown as string]: {
+        base: 'BTC',
+        quote: 'USDT',
+        priceScale,
+        qtyScale,
+      },
+    },
+    fee: { makerBps: 10, takerBps: 20 },
+    orderbook: new StaticMockOrderbook({ best: {} }),
+  });
+  const accounts = new AccountsService(state);
+  const orders = new OrdersService(state, accounts);
+  const buyAccount = accounts.createAccount('cli-sim-buy');
+  const sellAccount = accounts.createAccount('cli-sim-sell');
+  accounts.deposit(buyAccount.id, 'USDT', toPriceInt('100000', priceScale));
+  accounts.deposit(sellAccount.id, 'BTC', toQtyInt('2', qtyScale));
+  const placed: Order[] = [];
+  placed.push(
+    orders.placeOrder({
+      accountId: buyAccount.id,
+      symbol,
+      type: 'LIMIT',
+      side: 'BUY',
+      qty: toQtyInt('0.4', qtyScale),
+      price: toPriceInt('10010', priceScale),
+    }),
+  );
+  placed.push(
+    orders.placeOrder({
+      accountId: sellAccount.id,
+      symbol,
+      type: 'LIMIT',
+      side: 'SELL',
+      qty: toQtyInt('0.15', qtyScale),
+      price: toPriceInt('10005', priceScale),
+    }),
+  );
+  return { state, accounts, orders, placed, priceScale, qtyScale };
+}
+
+interface SummaryTotals {
+  orders: {
+    total: number;
+    filled: number;
+    partiallyFilled: number;
+    canceled: number;
+  };
+  fills: number;
+  executedQty: bigint;
+  notional: bigint;
+  fees: { maker: bigint; taker: bigint };
+}
+
+function buildSummary(
+  state: ExchangeState,
+  accounts: AccountsService,
+): {
+  totals: SummaryTotals;
+  orders: Array<{
+    id: string;
+    side: string;
+    status: string;
+    qty: bigint;
+    executedQty: bigint;
+    cumulativeQuote: bigint;
+    fees: { maker?: bigint; taker?: bigint };
+    fills: number;
+  }>;
+  balances: Record<string, Record<string, { free: bigint; locked: bigint }>>;
+} {
+  const ordersList = Array.from(state.orders.values());
+  const totals: SummaryTotals = {
+    orders: {
+      total: ordersList.length,
+      filled: 0,
+      partiallyFilled: 0,
+      canceled: 0,
+    },
+    fills: 0,
+    executedQty: 0n,
+    notional: 0n,
+    fees: { maker: 0n, taker: 0n },
+  };
+  const ordersSummary = ordersList.map((order) => {
+    if (order.status === 'FILLED') totals.orders.filled += 1;
+    if (order.status === 'PARTIALLY_FILLED') totals.orders.partiallyFilled += 1;
+    if (order.status === 'CANCELED') totals.orders.canceled += 1;
+    totals.fills += order.fills.length;
+    totals.executedQty += order.executedQty as unknown as bigint;
+    totals.notional += order.cumulativeQuote as unknown as bigint;
+    totals.fees.maker += order.fees.maker ?? 0n;
+    totals.fees.taker += order.fees.taker ?? 0n;
+    return {
+      id: order.id as unknown as string,
+      side: order.side,
+      status: order.status,
+      qty: order.qty as unknown as bigint,
+      executedQty: order.executedQty as unknown as bigint,
+      cumulativeQuote: order.cumulativeQuote as unknown as bigint,
+      fees: { ...order.fees },
+      fills: order.fills.length,
+    };
+  });
+  const balances: Record<
+    string,
+    Record<string, { free: bigint; locked: bigint }>
+  > = {};
+  for (const [id] of state.accounts.entries()) {
+    balances[id as unknown as string] = accounts.getBalancesSnapshot(id);
+  }
+  return { totals, orders: ordersSummary, balances };
+}
+
+export async function simulate(argv: string[]): Promise<void> {
+  const args = parseArgs(argv);
+  const tradeFiles = resolveInputList(args['trades']);
+  if (tradeFiles.length === 0) {
+    console.error(
+      'usage: tf simulate --trades <files> [--depth <files>] [--symbol BTCUSDT]',
+    );
+    process.exitCode = 1;
+    return;
+  }
+  const depthFiles = resolveInputList(args['depth']);
+  const symbol = (args['symbol'] ?? 'BTCUSDT') as SymbolId;
+  const limit = args['limit'] ? Number(args['limit']) : undefined;
+  const fromMs = parseTime(args['from']);
+  const toMs = parseTime(args['to']);
+  const ndjson = parseBool(args['ndjson'], false);
+  const printSummary = parseBool(args['summary'], true);
+  const preferDepth = parseBool(args['prefer-depth-on-equal-ts'], true);
+  const treatAsMaker = parseBool(args['treat-limit-as-maker'], true);
+  const timeFilter: { fromMs?: number; toMs?: number } = {};
+  if (fromMs !== undefined) timeFilter.fromMs = fromMs;
+  if (toMs !== undefined) timeFilter.toMs = toMs;
+
+  const tradeOpts: Record<string, unknown> = {
+    kind: 'trades',
+    files: tradeFiles,
+    symbol,
+    format: args['format-trades'] ?? 'auto',
+    internalTag: 'TRADES',
+  };
+  if (Object.keys(timeFilter).length) {
+    tradeOpts['timeFilter'] = timeFilter;
+  }
+  const tradeReader = createReader(
+    tradeOpts as any,
+  ) as AsyncIterable<TradeEvent>;
+
+  let depthReader: AsyncIterable<DepthEvent> = createEmptyStream();
+  if (depthFiles.length > 0) {
+    const depthOpts: Record<string, unknown> = {
+      kind: 'depth',
+      files: depthFiles,
+      symbol,
+      format: args['format-depth'] ?? 'auto',
+      internalTag: 'DEPTH',
+    };
+    if (Object.keys(timeFilter).length) {
+      depthOpts['timeFilter'] = timeFilter;
+    }
+    depthReader = createReader(depthOpts as any) as AsyncIterable<DepthEvent>;
+  }
+
+  const { state, accounts, placed, priceScale, qtyScale } = setupState(symbol);
+  const merged = createMergedStream(tradeReader, depthReader, {
+    preferDepthOnEqualTs: preferDepth,
+  });
+
+  const reports: ExecutionReport[] = [];
+  let printed = 0;
+  for await (const report of executeTimeline(merged, state, {
+    treatLimitAsMaker: treatAsMaker,
+  })) {
+    reports.push(report);
+    if (ndjson) {
+      if (limit === undefined || printed < limit) {
+        console.log(stringify(report));
+        printed += 1;
+      }
+    }
+  }
+
+  if (!ndjson && reports.length === 0) {
+    console.log('no execution reports emitted (check filters or inputs)');
+  }
+
+  if (printSummary) {
+    const summary = buildSummary(state, accounts);
+    summary['config'] = {
+      symbol,
+      priceScale,
+      qtyScale,
+      ordersSeeded: placed.map((o) => ({
+        id: o.id,
+        side: o.side,
+        qty: o.qty,
+        price: o.price,
+      })),
+    };
+    console.log(stringify(summary, 2));
+  }
+}

--- a/apps/cli/src/commands/simulate.ts
+++ b/apps/cli/src/commands/simulate.ts
@@ -294,17 +294,20 @@ export async function simulate(argv: string[]): Promise<void> {
 
   if (printSummary) {
     const summary = buildSummary(state, accounts);
-    summary['config'] = {
-      symbol,
-      priceScale,
-      qtyScale,
-      ordersSeeded: placed.map((o) => ({
-        id: o.id,
-        side: o.side,
-        qty: o.qty,
-        price: o.price,
-      })),
+    const summaryWithConfig = {
+      ...summary,
+      config: {
+        symbol,
+        priceScale,
+        qtyScale,
+        ordersSeeded: placed.map((o) => ({
+          id: o.id,
+          side: o.side,
+          qty: o.qty,
+          price: o.price,
+        })),
+      },
     };
-    console.log(stringify(summary, 2));
+    console.log(stringify(summaryWithConfig, 2));
   }
 }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,6 +1,7 @@
 import { dumpTrades } from './commands/dumpTrades.js';
 import { dumpDepth } from './commands/dumpDepth.js';
 import { replayDryRun } from './commands/replayDryRun.js';
+import { simulate } from './commands/simulate.js';
 
 export async function run(
   args: string[] = process.argv.slice(2),
@@ -32,8 +33,13 @@ export async function run(
       return;
     }
   }
+  if (cmd === 'simulate') {
+    const tail = [sub, ...rest].filter((v): v is string => Boolean(v));
+    await simulate(tail);
+    return;
+  }
   console.log(
-    'TradeForge CLI: available commands -> dump trades|depth, replay --dry-run',
+    'TradeForge CLI: available commands -> dump trades|depth, replay --dry-run, simulate',
   );
 }
 

--- a/apps/svc/tests/integration.rest.test.ts
+++ b/apps/svc/tests/integration.rest.test.ts
@@ -99,8 +99,8 @@ describe('REST adapter integration', () => {
       }
     >;
     expect(balancesAfterOrder['USDT']).toEqual({
-      free: '75000000',
-      locked: '25000000',
+      free: '74987500',
+      locked: '25012500',
     });
 
     const cancelRes = await app.inject({

--- a/packages/core/src/engine/execution.ts
+++ b/packages/core/src/engine/execution.ts
@@ -1,0 +1,110 @@
+import type { MergedEvent } from '../merge/timeline.js';
+import type { ExchangeState } from '../sim/state.js';
+import { AccountsService } from '../sim/accounts.js';
+import { OrdersService } from '../sim/orders.js';
+import type { Order } from '../sim/types.js';
+import type { QtyInt, TimestampMs } from '../types/index.js';
+import {
+  cloneFees,
+  compareOrdersForMatch,
+  createFill,
+  crossesLimitPrice,
+  determineLiquidity,
+  getOrderRemainingQty,
+} from './utils.js';
+import type { ExecutionOptions, ExecutionReport } from './types.js';
+
+const PARTICIPATION_FACTOR = 1n; // TODO: expose via options for strict conservative mode
+
+function minQty(a: bigint, b: bigint): bigint {
+  return a < b ? a : b;
+}
+
+function toQtyInt(value: bigint): QtyInt {
+  return value as QtyInt;
+}
+
+function buildOrderPatch(order: Order): Partial<Order> {
+  return {
+    status: order.status,
+    executedQty: order.executedQty,
+    cumulativeQuote: order.cumulativeQuote,
+    fees: cloneFees(order.fees),
+    tsUpdated: order.tsUpdated,
+  } satisfies Partial<Order>;
+}
+
+export async function* executeTimeline(
+  timeline: AsyncIterable<MergedEvent>,
+  state: ExchangeState,
+  options: ExecutionOptions = {},
+): AsyncIterable<ExecutionReport> {
+  const accounts = new AccountsService(state);
+  const orders = new OrdersService(state, accounts);
+  const treatLimitAsMaker = options.treatLimitAsMaker ?? true;
+  let lastTs: TimestampMs | undefined;
+
+  for await (const event of timeline) {
+    lastTs = event.ts;
+    if (event.kind !== 'trade') {
+      continue;
+    }
+    const trade = event.payload;
+    const openOrders = Array.from(orders.getOpenOrders(trade.symbol));
+    if (openOrders.length === 0) {
+      continue;
+    }
+    openOrders.sort(compareOrdersForMatch);
+    let remainingTradeQty =
+      (trade.qty as unknown as bigint) * PARTICIPATION_FACTOR;
+    if (remainingTradeQty <= 0n) {
+      continue;
+    }
+    for (const order of openOrders) {
+      if (remainingTradeQty <= 0n) {
+        break;
+      }
+      if (!crossesLimitPrice(order, trade.price)) {
+        continue;
+      }
+      const remainingOrderQty = getOrderRemainingQty(
+        order,
+      ) as unknown as bigint;
+      if (remainingOrderQty <= 0n) {
+        continue;
+      }
+      const fillQtyRaw = minQty(remainingOrderQty, remainingTradeQty);
+      if (fillQtyRaw <= 0n) {
+        continue;
+      }
+      const fillQty = toQtyInt(fillQtyRaw);
+      const liquidity = determineLiquidity(order, {
+        treatLimitAsMaker,
+        ...(trade.side ? { aggressorSide: trade.side } : {}),
+      });
+      const fill = createFill({
+        ts: event.ts,
+        order,
+        price: trade.price,
+        qty: fillQty,
+        liquidity,
+        ...(trade.id ? { tradeRef: trade.id } : {}),
+      });
+      const updated = orders.applyFill(order.id, fill);
+      remainingTradeQty -= fillQtyRaw;
+      yield {
+        ts: event.ts,
+        kind: 'FILL',
+        orderId: order.id,
+        fill,
+        patch: buildOrderPatch(updated),
+      } satisfies ExecutionReport;
+      if (updated.status === 'FILLED') {
+        orders.closeOrder(order.id, 'FILLED');
+      }
+    }
+  }
+
+  const endTs = lastTs ?? (0 as TimestampMs);
+  yield { ts: endTs, kind: 'END' } satisfies ExecutionReport;
+}

--- a/packages/core/src/engine/types.ts
+++ b/packages/core/src/engine/types.ts
@@ -1,0 +1,34 @@
+import type {
+  Liquidity,
+  OrderId,
+  PriceInt,
+  QtyInt,
+  Side,
+  TimestampMs,
+} from '../types/index.js';
+import type { Order } from '../sim/types.js';
+
+export interface Fill {
+  ts: TimestampMs;
+  orderId: OrderId;
+  price: PriceInt;
+  qty: QtyInt;
+  side: Side;
+  liquidity: Liquidity;
+  tradeRef?: string;
+}
+
+export type ExecutionReportKind = 'FILL' | 'ORDER_UPDATED' | 'END';
+
+export interface ExecutionReport {
+  ts: TimestampMs;
+  kind: ExecutionReportKind;
+  orderId?: OrderId;
+  patch?: Partial<Order>;
+  fill?: Fill;
+}
+
+export interface ExecutionOptions {
+  preferDepthOnEqualTs?: boolean;
+  treatLimitAsMaker?: boolean;
+}

--- a/packages/core/src/engine/utils.ts
+++ b/packages/core/src/engine/utils.ts
@@ -1,0 +1,90 @@
+import type {
+  Liquidity,
+  PriceInt,
+  QtyInt,
+  Side,
+  TimestampMs,
+} from '../types/index.js';
+import type { Order } from '../sim/types.js';
+import type { Fill } from './types.js';
+
+interface LiquidityOptions {
+  treatLimitAsMaker?: boolean;
+  aggressorSide?: Side;
+}
+
+export function determineLiquidity(
+  order: Order,
+  options: LiquidityOptions = {},
+): Liquidity {
+  if (options.treatLimitAsMaker ?? true) {
+    return 'MAKER';
+  }
+  const aggressor = options.aggressorSide;
+  if (!aggressor) {
+    return 'TAKER';
+  }
+  return aggressor === order.side ? 'TAKER' : 'MAKER';
+}
+
+export function createFill(params: {
+  ts: TimestampMs;
+  order: Order;
+  price: PriceInt;
+  qty: QtyInt;
+  liquidity: Liquidity;
+  tradeRef?: string;
+}): Fill {
+  const fill: Fill = {
+    ts: params.ts,
+    orderId: params.order.id,
+    price: params.price,
+    qty: params.qty,
+    side: params.order.side,
+    liquidity: params.liquidity,
+  };
+  if (params.tradeRef !== undefined) {
+    fill.tradeRef = params.tradeRef;
+  }
+  return fill;
+}
+
+export function compareOrdersForMatch(a: Order, b: Order): number {
+  if (a.tsCreated !== b.tsCreated) {
+    return (
+      (a.tsCreated as unknown as number) - (b.tsCreated as unknown as number)
+    );
+  }
+  if (a.id === b.id) {
+    return 0;
+  }
+  return a.id < b.id ? -1 : 1;
+}
+
+export function getOrderRemainingQty(order: Order): QtyInt {
+  const total = order.qty as unknown as bigint;
+  const executed = order.executedQty as unknown as bigint;
+  const remaining = total - executed;
+  return (remaining > 0n ? remaining : 0n) as QtyInt;
+}
+
+export function crossesLimitPrice(order: Order, tradePrice: PriceInt): boolean {
+  if (!order.price) {
+    return false;
+  }
+  if (order.side === 'BUY') {
+    return tradePrice <= order.price;
+  }
+  return tradePrice >= order.price;
+}
+
+export function cloneFees(fees: Order['fees']): Order['fees'] {
+  const next: Order['fees'] = {};
+  if (fees.maker !== undefined) {
+    next.maker = fees.maker;
+  }
+  if (fees.taker !== undefined) {
+    next.taker = fees.taker;
+  }
+  return next;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,3 +4,5 @@ export * from './fp/scale.js';
 export * from './utils/guards.js';
 export * from './merge/timeline.js';
 export * from './sim/index.js';
+export * from './engine/execution.js';
+export * from './engine/types.js';

--- a/packages/core/src/sim/types.ts
+++ b/packages/core/src/sim/types.ts
@@ -1,11 +1,13 @@
 import type { brand } from '../types/brands.js';
 import type {
+  NotionalInt,
   OrderId,
   PriceInt,
   QtyInt,
   SymbolId,
   TimestampMs,
 } from '../types/index.js';
+import type { Fill } from '../engine/types.js';
 import type { OrderbookProvider } from './orderbook.mock.js';
 
 export type AccountId = brand<string, 'AccountId'>;
@@ -32,7 +34,13 @@ export interface SymbolConfig {
 export type OrderType = 'LIMIT' | 'MARKET' | 'STOP_LIMIT' | 'STOP_MARKET';
 export type OrderSide = 'BUY' | 'SELL';
 export type TimeInForce = 'GTC' | 'IOC' | 'FOK';
-export type OrderStatus = 'NEW' | 'OPEN' | 'CANCELED' | 'REJECTED';
+export type OrderStatus =
+  | 'NEW'
+  | 'OPEN'
+  | 'PARTIALLY_FILLED'
+  | 'FILLED'
+  | 'CANCELED'
+  | 'REJECTED';
 
 export type RejectReason =
   | 'UNSUPPORTED_EXECUTION'
@@ -53,6 +61,18 @@ export interface Order {
   status: OrderStatus;
   rejectReason?: RejectReason;
   accountId: AccountId;
+  executedQty: QtyInt;
+  cumulativeQuote: NotionalInt;
+  fees: {
+    maker?: bigint;
+    taker?: bigint;
+  };
+  fills: Fill[];
+  reserved?: {
+    currency: Currency;
+    total: bigint;
+    remaining: bigint;
+  };
 }
 
 export interface FeeConfig {

--- a/packages/core/tests/engine.execution.test.ts
+++ b/packages/core/tests/engine.execution.test.ts
@@ -1,0 +1,289 @@
+import {
+  AccountsService,
+  ExchangeState,
+  OrdersService,
+  StaticMockOrderbook,
+  calcFee,
+  executeTimeline,
+  toPriceInt,
+  toQtyInt,
+  type ExecutionReport,
+  type MergedEvent,
+  type Order,
+  type SymbolId,
+  type TimestampMs,
+  type Trade,
+} from '../src/index';
+
+const SYMBOL = 'BTCUSDT' as SymbolId;
+const PRICE_SCALE = 2;
+const QTY_SCALE = 3;
+const FEE_BPS = { makerBps: 10, takerBps: 20 } as const;
+const QTY_DENOM = BigInt(10 ** QTY_SCALE);
+
+function rawPrice(value: string): bigint {
+  return toPriceInt(value, PRICE_SCALE) as unknown as bigint;
+}
+
+function rawQty(value: string): bigint {
+  return toQtyInt(value, QTY_SCALE) as unknown as bigint;
+}
+
+function notional(price: string, qty: string): bigint {
+  return (rawPrice(price) * rawQty(qty)) / QTY_DENOM;
+}
+
+function createState() {
+  const state = new ExchangeState({
+    symbols: {
+      [SYMBOL as unknown as string]: {
+        base: 'BTC',
+        quote: 'USDT',
+        priceScale: PRICE_SCALE,
+        qtyScale: QTY_SCALE,
+      },
+    },
+    fee: { makerBps: FEE_BPS.makerBps, takerBps: FEE_BPS.takerBps },
+    orderbook: new StaticMockOrderbook({ best: {} }),
+  });
+  const accounts = new AccountsService(state);
+  const orders = new OrdersService(state, accounts);
+  return { state, accounts, orders };
+}
+
+function tradeEvent(
+  ts: number,
+  price: string,
+  qty: string,
+  id?: string,
+  side?: 'BUY' | 'SELL',
+): MergedEvent {
+  const tsMs = ts as TimestampMs;
+  const priceInt = toPriceInt(price, PRICE_SCALE);
+  const qtyInt = toQtyInt(qty, QTY_SCALE);
+  const payload: Trade = {
+    ts: tsMs,
+    symbol: SYMBOL,
+    price: priceInt,
+    qty: qtyInt,
+  };
+  if (side) {
+    payload.side = side;
+  }
+  if (id !== undefined) {
+    payload.id = id;
+  }
+  return {
+    kind: 'trade',
+    ts: tsMs,
+    source: 'TRADES',
+    seq: ts,
+    payload,
+  } satisfies MergedEvent;
+}
+
+async function collect<T>(iter: AsyncIterable<T>): Promise<T[]> {
+  const result: T[] = [];
+  for await (const item of iter) {
+    result.push(item);
+  }
+  return result;
+}
+
+function assertOrderSnapshot(order: Order) {
+  expect(order.fills).toBeDefined();
+  expect(Array.isArray(order.fills)).toBe(true);
+}
+
+describe('executeTimeline', () => {
+  it('partially fills BUY limit order and tracks fees/balances', async () => {
+    const { state, accounts, orders } = createState();
+    const account = accounts.createAccount('buyer');
+    const depositAmount = toPriceInt('200', PRICE_SCALE);
+    accounts.deposit(account.id, 'USDT', depositAmount);
+
+    const order = orders.placeOrder({
+      accountId: account.id,
+      symbol: SYMBOL,
+      type: 'LIMIT',
+      side: 'BUY',
+      qty: toQtyInt('1', QTY_SCALE),
+      price: toPriceInt('100', PRICE_SCALE),
+    });
+    expect(order.status).toBe('OPEN');
+
+    const events: MergedEvent[] = [
+      tradeEvent(1, '99', '0.3', 't1', 'SELL'),
+      tradeEvent(2, '101', '0.5', 't2', 'BUY'),
+    ];
+
+    const reports = await collect(
+      executeTimeline(
+        (async function* () {
+          for (const event of events) {
+            yield event;
+          }
+        })(),
+        state,
+      ),
+    );
+
+    expect(reports).toHaveLength(2);
+    const [fillReport, endReport] = reports as [
+      ExecutionReport,
+      ExecutionReport,
+    ];
+    expect(fillReport.kind).toBe('FILL');
+    expect(fillReport.orderId).toBe(order.id);
+    expect(fillReport.fill?.qty).toEqual(toQtyInt('0.3', QTY_SCALE));
+    expect(fillReport.fill?.price).toEqual(toPriceInt('99', PRICE_SCALE));
+    expect(fillReport.patch?.status).toBe('PARTIALLY_FILLED');
+    expect(endReport.kind).toBe('END');
+
+    const updated = orders.getOrder(order.id);
+    assertOrderSnapshot(updated);
+    expect(updated.status).toBe('PARTIALLY_FILLED');
+    expect(updated.executedQty).toEqual(toQtyInt('0.3', QTY_SCALE));
+    expect(updated.fills).toHaveLength(1);
+
+    const expectedNotional = notional('99', '0.3');
+    expect(updated.cumulativeQuote).toEqual(
+      expectedNotional as unknown as Order['cumulativeQuote'],
+    );
+    const expectedFee = calcFee(expectedNotional, FEE_BPS.makerBps);
+    expect(updated.fees.maker).toEqual(expectedFee);
+
+    const quoteBalance = accounts.getBalance(account.id, 'USDT');
+    const baseBalance = accounts.getBalance(account.id, 'BTC');
+    expect(baseBalance.free).toEqual(toQtyInt('0.3', QTY_SCALE));
+    expect(quoteBalance.locked).toEqual(updated.reserved?.remaining ?? 0n);
+    const reservedTotal = updated.reserved?.total ?? 0n;
+    expect(reservedTotal).toBeGreaterThan(updated.reserved?.remaining ?? 0n);
+  });
+
+  it('fills SELL limit order across multiple trades and releases locked base', async () => {
+    const { state, accounts, orders } = createState();
+    const account = accounts.createAccount('seller');
+    const baseDeposit = toQtyInt('1', QTY_SCALE);
+    accounts.deposit(account.id, 'BTC', baseDeposit);
+
+    const order = orders.placeOrder({
+      accountId: account.id,
+      symbol: SYMBOL,
+      type: 'LIMIT',
+      side: 'SELL',
+      qty: toQtyInt('0.6', QTY_SCALE),
+      price: toPriceInt('100', PRICE_SCALE),
+    });
+    expect(order.status).toBe('OPEN');
+
+    const events = [
+      tradeEvent(1, '101', '0.4', 's1', 'BUY'),
+      tradeEvent(2, '100', '0.2', 's2', 'BUY'),
+    ];
+
+    await collect(
+      executeTimeline(
+        (async function* () {
+          for (const event of events) {
+            yield event;
+          }
+        })(),
+        state,
+      ),
+    );
+
+    const updated = orders.getOrder(order.id);
+    assertOrderSnapshot(updated);
+    expect(updated.status).toBe('FILLED');
+    expect(updated.executedQty).toEqual(toQtyInt('0.6', QTY_SCALE));
+    expect(updated.fills).toHaveLength(2);
+
+    const firstNotional = notional('101', '0.4');
+    const secondNotional = notional('100', '0.2');
+    const totalNotional = firstNotional + secondNotional;
+    expect(updated.cumulativeQuote).toEqual(
+      totalNotional as unknown as Order['cumulativeQuote'],
+    );
+    const expectedFee =
+      calcFee(firstNotional, FEE_BPS.makerBps) +
+      calcFee(secondNotional, FEE_BPS.makerBps);
+    expect(updated.fees.maker).toEqual(expectedFee);
+
+    const quoteBalance = accounts.getBalance(account.id, 'USDT');
+    const baseBalance = accounts.getBalance(account.id, 'BTC');
+    expect(baseBalance.locked).toBe(0n);
+    expect(updated.reserved?.remaining).toBe(0n);
+    expect(quoteBalance.free).toEqual(totalNotional - expectedFee);
+  });
+
+  it('returns unused quote reserve after BUY order fills below limit price', async () => {
+    const { state, accounts, orders } = createState();
+    const account = accounts.createAccount('buyer-fill');
+    accounts.deposit(account.id, 'USDT', toPriceInt('500', PRICE_SCALE));
+
+    const order = orders.placeOrder({
+      accountId: account.id,
+      symbol: SYMBOL,
+      type: 'LIMIT',
+      side: 'BUY',
+      qty: toQtyInt('0.2', QTY_SCALE),
+      price: toPriceInt('110', PRICE_SCALE),
+    });
+    expect(order.status).toBe('OPEN');
+
+    await collect(
+      executeTimeline(
+        (async function* () {
+          yield tradeEvent(1, '100', '0.2', 'b1', 'SELL');
+        })(),
+        state,
+      ),
+    );
+
+    const updated = orders.getOrder(order.id);
+    expect(updated.status).toBe('FILLED');
+    expect(updated.reserved?.remaining).toBe(0n);
+    expect(updated.fills).toHaveLength(1);
+
+    const quoteBalance = accounts.getBalance(account.id, 'USDT');
+    const fillNotional = notional('100', '0.2');
+    const fee = calcFee(fillNotional, FEE_BPS.makerBps);
+    const spent = fillNotional + fee;
+    expect(quoteBalance.locked).toBe(0n);
+    expect(quoteBalance.free).toEqual(toPriceInt('500', PRICE_SCALE) - spent);
+  });
+
+  it('produces deterministic reports for identical timelines', async () => {
+    const scenario = () => {
+      const { state, accounts, orders } = createState();
+      const account = accounts.createAccount('det');
+      accounts.deposit(account.id, 'USDT', toPriceInt('300', PRICE_SCALE));
+      orders.placeOrder({
+        accountId: account.id,
+        symbol: SYMBOL,
+        type: 'LIMIT',
+        side: 'BUY',
+        qty: toQtyInt('0.5', QTY_SCALE),
+        price: toPriceInt('100', PRICE_SCALE),
+      });
+      const events = [
+        tradeEvent(1, '100', '0.2', 'd1', 'SELL'),
+        tradeEvent(2, '100', '0.3', 'd2', 'SELL'),
+      ];
+      return collect(
+        executeTimeline(
+          (async function* () {
+            for (const event of events) {
+              yield event;
+            }
+          })(),
+          state,
+        ),
+      );
+    };
+
+    const [first, second] = await Promise.all([scenario(), scenario()]);
+    expect(first).toEqual(second);
+  });
+});


### PR DESCRIPTION
## Summary
- implement a conservative execution engine that processes limit orders against historical trade events, updating order fills, fees and balances
- extend account and order services to manage reservations, partial fills and fee application and add thorough engine integration tests
- introduce a `tf simulate` CLI command for running simulations and adjust REST tests for the updated reservation accounting

## Testing
- pnpm -w build
- pnpm -w test
- pnpm --filter @tradeforge/cli dev -- simulate --trades packages/io-binance/tests/fixtures/trades.jsonl --symbol BTCUSDT --summary
- pnpm --filter @tradeforge/cli dev -- simulate --trades packages/io-binance/tests/fixtures/trades.jsonl --ndjson --limit 5

------
https://chatgpt.com/codex/tasks/task_e_68c8f8bef9d88320a302cf7abb468829