### PR TITLE
Fix ts-jest module resolution for workspace packages

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,6 +3,11 @@
     "target": "ES2022",
     "module": "node16",
     "moduleResolution": "node16",
+    "baseUrl": ".",
+    "paths": {
+      "@tradeforge/core": ["packages/core/src/index.ts"],
+      "@tradeforge/io-binance": ["packages/io-binance/src/index.ts"]
+    },
     "strict": true,
     "exactOptionalPropertyTypes": true,
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
## Summary
- add workspace path mappings to the shared TypeScript configuration so Jest can resolve @tradeforge packages during tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68c98d52035883208bd30a8466ab0530