### PR TITLE
feat(io-binance,core): JSONL cursor readers (non-breaking) + minimal merge start state

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export * from './fp/fixedPoint.js';
 export * from './fp/scale.js';
 export * from './utils/guards.js';
 export * from './merge/timeline.js';
+export * from './merge/start.js';
 export * from './sim/index.js';
 export * from './engine/execution.js';
 export * from './engine/types.js';

--- a/packages/core/src/merge/start.ts
+++ b/packages/core/src/merge/start.ts
@@ -1,0 +1,7 @@
+export type CursorIterable<T> = AsyncIterable<T> & {
+  currentCursor?: () => unknown;
+};
+
+export interface MergeStartState {
+  nextSourceOnEqualTs?: 'DEPTH' | 'TRADES';
+}

--- a/packages/core/src/merge/timeline.ts
+++ b/packages/core/src/merge/timeline.ts
@@ -1,4 +1,5 @@
 import type { DepthDiff, TimestampMs, Trade } from '../types/index.js';
+import type { CursorIterable, MergeStartState } from './start.js';
 
 export type SourceTag = 'DEPTH' | 'TRADES';
 
@@ -31,6 +32,30 @@ type StreamState<TEvent extends MergedEvent> = {
 
 type EntryOrderMap = Record<SourceTag, Map<string, number>>;
 
+interface TieBreakerState {
+  next?: SourceTag;
+}
+
+function compareSourcesWithStart(
+  a: SourceTag,
+  b: SourceTag,
+  preferDepth: boolean,
+  tieBreaker?: TieBreakerState,
+): number {
+  if (tieBreaker?.next) {
+    const preferred = tieBreaker.next;
+    if (preferred === a && preferred !== b) {
+      delete tieBreaker.next;
+      return -1;
+    }
+    if (preferred === b && preferred !== a) {
+      delete tieBreaker.next;
+      return 1;
+    }
+  }
+  return compareBySource(a, b, preferDepth);
+}
+
 function compareBySource(
   a: SourceTag,
   b: SourceTag,
@@ -61,13 +86,14 @@ function compareEvents(
   preferDepth: boolean,
   entryOrder: EntryOrderMap,
   fallbackOrder: WeakMap<MergedEvent, number>,
+  tieBreaker?: TieBreakerState,
 ): number {
   if (a === b) return 0;
   if (a.ts !== b.ts) {
     return a.ts < b.ts ? -1 : 1;
   }
   if (a.source !== b.source) {
-    return compareBySource(a.source, b.source, preferDepth);
+    return compareSourcesWithStart(a.source, b.source, preferDepth, tieBreaker);
   }
   if (a.seq !== b.seq) {
     return a.seq < b.seq ? -1 : 1;
@@ -118,9 +144,28 @@ async function pullNext<TEvent extends MergedEvent>(
 export function createMergedStream(
   trades: AsyncIterable<TradeEvent>,
   depth: AsyncIterable<DepthEvent>,
-  opts: MergeOptions = {},
+  opts?: MergeOptions,
+): AsyncIterable<MergedEvent>;
+export function createMergedStream(
+  trades: CursorIterable<TradeEvent> | AsyncIterable<TradeEvent>,
+  depth: CursorIterable<DepthEvent> | AsyncIterable<DepthEvent>,
+  start?: MergeStartState,
+  opts?: MergeOptions,
+): AsyncIterable<MergedEvent>;
+export function createMergedStream(
+  trades: CursorIterable<TradeEvent> | AsyncIterable<TradeEvent>,
+  depth: CursorIterable<DepthEvent> | AsyncIterable<DepthEvent>,
+  arg2?: MergeOptions | MergeStartState,
+  arg3?: MergeOptions,
 ): AsyncIterable<MergedEvent> {
-  const preferDepth = opts.preferDepthOnEqualTs ?? true;
+  const hasStartArg =
+    arguments.length >= 4 ||
+    (arg2 && typeof arg2 === 'object' && 'nextSourceOnEqualTs' in arg2);
+  const start = hasStartArg ? (arg2 as MergeStartState | undefined) : undefined;
+  const options = hasStartArg
+    ? (arg3 ?? {})
+    : ((arg2 as MergeOptions | undefined) ?? {});
+  const preferDepth = options.preferDepthOnEqualTs ?? true;
   const entryOrder: EntryOrderMap = {
     DEPTH: new Map(),
     TRADES: new Map(),
@@ -142,6 +187,10 @@ export function createMergedStream(
         fallbackCounter: 0,
         expectedSource: 'DEPTH',
       };
+      const tieBreakerState: TieBreakerState = {};
+      if (start?.nextSourceOnEqualTs) {
+        tieBreakerState.next = start.nextSourceOnEqualTs;
+      }
       const states: StreamState<MergedEvent>[] = [
         tradeState as unknown as StreamState<MergedEvent>,
         depthState as unknown as StreamState<MergedEvent>,
@@ -163,6 +212,7 @@ export function createMergedStream(
             preferDepth,
             entryOrder,
             fallbackOrder,
+            tieBreakerState,
           );
           if (cmp < 0) {
             bestState = state;

--- a/packages/core/tests/merge.start.minimal.test.ts
+++ b/packages/core/tests/merge.start.minimal.test.ts
@@ -1,0 +1,100 @@
+import {
+  createMergedStream,
+  MergeStartState,
+  TradeEvent,
+  DepthEvent,
+  TimestampMs,
+  SymbolId,
+  PriceInt,
+  QtyInt,
+} from '../src/index';
+
+const SYMBOL = 'BTCUSDT' as SymbolId;
+
+function toAsync<T>(items: T[]): AsyncIterable<T> {
+  return {
+    async *[Symbol.asyncIterator](): AsyncIterator<T> {
+      for (const item of items) {
+        yield item;
+      }
+    },
+  };
+}
+
+async function collect(iter: AsyncIterable<TradeEvent | DepthEvent>) {
+  const out: (TradeEvent | DepthEvent)[] = [];
+  for await (const value of iter) {
+    out.push(value);
+  }
+  return out;
+}
+
+function makeTradeEvent(ts: number, seq: number): TradeEvent {
+  const payload = {
+    ts: ts as TimestampMs,
+    symbol: SYMBOL,
+    price: BigInt(10000 + seq) as PriceInt,
+    qty: BigInt(1 + seq) as QtyInt,
+  };
+  return {
+    kind: 'trade',
+    ts: payload.ts,
+    payload,
+    source: 'TRADES',
+    seq,
+    entry: 'trades.jsonl',
+  };
+}
+
+function makeDepthEvent(ts: number, seq: number): DepthEvent {
+  const payload = {
+    ts: ts as TimestampMs,
+    symbol: SYMBOL,
+    bids: [
+      {
+        price: BigInt(10000 + seq) as PriceInt,
+        qty: BigInt(10 + seq) as QtyInt,
+      },
+    ],
+    asks: [],
+  };
+  return {
+    kind: 'depth',
+    ts: payload.ts,
+    payload,
+    source: 'DEPTH',
+    seq,
+    entry: 'depth.jsonl',
+  };
+}
+
+test('start.nextSourceOnEqualTs overrides only the first tie', async () => {
+  const trades = [makeTradeEvent(1, 0), makeTradeEvent(2, 1)];
+  const depth = [makeDepthEvent(1, 0), makeDepthEvent(2, 1)];
+  const start: MergeStartState = { nextSourceOnEqualTs: 'TRADES' };
+
+  const merged = createMergedStream(toAsync(trades), toAsync(depth), start, {
+    preferDepthOnEqualTs: true,
+  });
+  const result = await collect(merged);
+  expect(result.map((e) => [e.source, Number(e.ts)])).toEqual([
+    ['TRADES', 1],
+    ['DEPTH', 1],
+    ['DEPTH', 2],
+    ['TRADES', 2],
+  ]);
+
+  const mergedRepeat = createMergedStream(
+    toAsync(trades),
+    toAsync(depth),
+    start,
+    { preferDepthOnEqualTs: true },
+  );
+  const repeat = await collect(mergedRepeat);
+  expect(repeat.map((e) => [e.source, Number(e.ts)])).toEqual([
+    ['TRADES', 1],
+    ['DEPTH', 1],
+    ['DEPTH', 2],
+    ['TRADES', 2],
+  ]);
+});

--- a/packages/io-binance/src/cursors/jsonl.cursor.ts
+++ b/packages/io-binance/src/cursors/jsonl.cursor.ts
@@ -1,0 +1,231 @@
+import { createReadStream } from 'node:fs';
+import { Readable } from 'node:stream';
+import { createGunzip } from 'node:zlib';
+import fg from 'fast-glob';
+import unzipper from 'unzipper';
+import type { DepthDiff, SymbolId, Trade } from '@tradeforge/core';
+import { parseJsonl } from '../parse/jsonl.js';
+import { normalizeTrade } from '../normalize/trades.js';
+import { normalizeDepth } from '../normalize/depth.js';
+import type {
+  CursorIterable,
+  JsonlCursorDepthOptions,
+  JsonlCursorReaderOptions,
+  JsonlCursorTradesOptions,
+  ReaderCursor,
+} from './types.js';
+
+interface JsonlSource {
+  file: string;
+  entry?: string;
+  lines: AsyncIterable<string>;
+}
+
+async function* lineSplitter(stream: Readable): AsyncIterable<string> {
+  let buffer = '';
+  for await (const chunk of stream) {
+    buffer += chunk.toString('utf8');
+    let idx = buffer.indexOf('\n');
+    while (idx >= 0) {
+      const line = buffer.slice(0, idx).replace(/\r$/, '');
+      buffer = buffer.slice(idx + 1);
+      yield line;
+      idx = buffer.indexOf('\n');
+    }
+  }
+  if (buffer.length > 0) {
+    yield buffer.replace(/\r$/, '');
+  }
+}
+
+async function expand(files: string[]): Promise<string[]> {
+  const out: string[] = [];
+  for (const file of files) {
+    if (/[\\*\?]/.test(file)) {
+      const found = await fg(file, { dot: false });
+      out.push(...found);
+    } else {
+      out.push(file);
+    }
+  }
+  return out;
+}
+
+function isJsonl(path: string): boolean {
+  return path.toLowerCase().endsWith('.jsonl');
+}
+
+function isJsonlGzip(path: string): boolean {
+  return path.toLowerCase().endsWith('.jsonl.gz');
+}
+
+function isJsonlZip(path: string): boolean {
+  return path.toLowerCase().endsWith('.jsonl.zip');
+}
+
+function ensureSupported(path: string): void {
+  if (isJsonl(path) || isJsonlGzip(path) || isJsonlZip(path)) {
+    return;
+  }
+  throw new Error(
+    `createJsonlCursorReader supports only JSONL files (*.jsonl, *.jsonl.gz, *.jsonl.zip); received: ${path}`,
+  );
+}
+
+async function openRegular(path: string): Promise<JsonlSource> {
+  const stream = createReadStream(path);
+  stream.setEncoding('utf8');
+  return { file: path, lines: lineSplitter(stream) };
+}
+
+async function openGzip(path: string): Promise<JsonlSource> {
+  const stream = createReadStream(path).pipe(createGunzip());
+  (stream as unknown as Readable).setEncoding('utf8');
+  return { file: path, lines: lineSplitter(stream as unknown as Readable) };
+}
+
+async function openZip(path: string): Promise<JsonlSource> {
+  const directory = await unzipper.Open.file(path);
+  const entries = [...directory.files].sort((a, b) =>
+    a.path.localeCompare(b.path),
+  );
+  if (entries.length !== 1) {
+    throw new Error('multi-entry zip is not supported in PR-8b');
+  }
+  const entry = entries[0];
+  if (!isJsonl(entry.path)) {
+    throw new Error(
+      `createJsonlCursorReader expects .jsonl entry inside zip; received: ${entry.path}`,
+    );
+  }
+  const stream = entry.stream();
+  (stream as unknown as Readable).setEncoding('utf8');
+  return {
+    file: path,
+    entry: entry.path,
+    lines: lineSplitter(stream as unknown as Readable),
+  };
+}
+
+async function openSource(path: string): Promise<JsonlSource> {
+  if (isJsonl(path)) return openRegular(path);
+  if (isJsonlGzip(path)) return openGzip(path);
+  if (isJsonlZip(path)) return openZip(path);
+  ensureSupported(path);
+  return openRegular(path);
+}
+
+function isWithinFrom(ts: number, from?: number): boolean {
+  return from === undefined || ts >= from;
+}
+
+function isWithinTo(ts: number, to?: number): boolean {
+  return to === undefined || ts <= to;
+}
+
+export function createJsonlCursorReader(
+  opts: JsonlCursorTradesOptions,
+): CursorIterable<Trade>;
+export function createJsonlCursorReader(
+  opts: JsonlCursorDepthOptions,
+): CursorIterable<DepthDiff>;
+export function createJsonlCursorReader(
+  opts: JsonlCursorReaderOptions,
+): CursorIterable<Trade | DepthDiff> {
+  const filesPromise = expand(opts.files);
+  const startCursor = opts.startCursor;
+  if (startCursor && startCursor.recordIndex < 0) {
+    throw new Error('startCursor.recordIndex must be >= 0');
+  }
+  const cursor: ReaderCursor = startCursor
+    ? { ...startCursor }
+    : { file: '', recordIndex: 0 };
+  const symbol = (opts.symbol ?? ('BTCUSDT' as SymbolId)) as SymbolId;
+  const isTrades = opts.kind === 'trades';
+  const timeFilter = opts.timeFilter;
+  const limit = opts.limit;
+  const assertMonotonic = opts.assertMonotonicTimestamps ?? false;
+
+  return {
+    currentCursor(): ReaderCursor {
+      return { ...cursor };
+    },
+    async *[Symbol.asyncIterator](): AsyncIterator<Trade | DepthDiff> {
+      const files = await filesPromise;
+      let emitted = 0;
+      let prevTs: number | undefined;
+      let startLocated = !startCursor;
+      let startActivated = !startCursor;
+      for (const filePath of files) {
+        ensureSupported(filePath);
+        const source = await openSource(filePath);
+        const matchesCursor =
+          startCursor &&
+          filePath === startCursor.file &&
+          (startCursor.entry ?? undefined) === (source.entry ?? undefined);
+        if (startCursor && !startActivated) {
+          if (!matchesCursor) {
+            continue;
+          }
+          startActivated = true;
+          startLocated = true;
+          cursor.file = filePath;
+          if (source.entry === undefined) {
+            delete cursor.entry;
+          } else {
+            cursor.entry = source.entry;
+          }
+          cursor.recordIndex = startCursor.recordIndex;
+        } else {
+          cursor.file = filePath;
+          if (source.entry === undefined) {
+            delete cursor.entry;
+          } else {
+            cursor.entry = source.entry;
+          }
+          cursor.recordIndex = 0;
+        }
+        let skipRecords = matchesCursor ? (startCursor?.recordIndex ?? 0) : 0;
+        const records = parseJsonl(source.lines) as AsyncIterable<
+          Record<string, unknown>
+        >;
+        for await (const raw of records) {
+          const normalized = isTrades
+            ? normalizeTrade(raw, { symbol })
+            : normalizeDepth(raw, { symbol });
+          const ts = normalized.ts as unknown as number;
+          if (timeFilter) {
+            if (!isWithinFrom(ts, timeFilter.fromMs)) {
+              continue;
+            }
+            if (!isWithinTo(ts, timeFilter.toMs)) {
+              continue;
+            }
+          }
+          if (skipRecords && skipRecords > 0) {
+            skipRecords -= 1;
+            continue;
+          }
+          if (assertMonotonic && prevTs !== undefined && ts < prevTs) {
+            const location = source.entry ?? source.file;
+            throw new Error(
+              `timestamp decreased: prev=${prevTs} current=${ts} file=${location}`,
+            );
+          }
+          prevTs = ts;
+          cursor.recordIndex += 1;
+          yield normalized;
+          emitted += 1;
+          if (limit && emitted >= limit) {
+            return;
+          }
+        }
+      }
+      if (startCursor && !startLocated) {
+        throw new Error(
+          `startCursor file not found in provided files: ${startCursor.file}`,
+        );
+      }
+    },
+  };
+}

--- a/packages/io-binance/src/cursors/types.ts
+++ b/packages/io-binance/src/cursors/types.ts
@@ -1,0 +1,33 @@
+import type { SymbolId } from '@tradeforge/core';
+
+export interface ReaderCursor {
+  file: string;
+  entry?: string;
+  recordIndex: number;
+}
+
+export interface CursorIterable<T> extends AsyncIterable<T> {
+  currentCursor(): ReaderCursor;
+}
+
+interface JsonlCursorReaderBaseOptions {
+  files: string[];
+  symbol?: SymbolId;
+  timeFilter?: { fromMs?: number; toMs?: number };
+  limit?: number;
+  assertMonotonicTimestamps?: boolean;
+  startCursor?: ReaderCursor;
+}
+
+export interface JsonlCursorTradesOptions extends JsonlCursorReaderBaseOptions {
+  kind: 'trades';
+}
+
+export interface JsonlCursorDepthOptions extends JsonlCursorReaderBaseOptions {
+  kind: 'depth';
+  depthShape?: 'binance-spot-diff' | 'custom';
+}
+
+export type JsonlCursorReaderOptions =
+  | JsonlCursorTradesOptions
+  | JsonlCursorDepthOptions;

--- a/packages/io-binance/src/index.ts
+++ b/packages/io-binance/src/index.ts
@@ -130,6 +130,14 @@ export async function* createReader(
   }
 }
 
+export { createJsonlCursorReader } from './cursors/jsonl.cursor.js';
+export type {
+  ReaderCursor,
+  CursorIterable,
+  JsonlCursorReaderOptions,
+  JsonlCursorTradesOptions,
+  JsonlCursorDepthOptions,
+} from './cursors/types.js';
 export type {
   Trade,
   DepthDiff,

--- a/packages/io-binance/tests/jsonl.cursors.depth.test.ts
+++ b/packages/io-binance/tests/jsonl.cursors.depth.test.ts
@@ -1,0 +1,117 @@
+/* eslint-disable */
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { gzipSync } from 'node:zlib';
+import type { DepthDiff } from '@tradeforge/core';
+import { createJsonlCursorReader } from '../src/index.js';
+
+async function collectDepth(
+  iter: AsyncIterable<DepthDiff>,
+): Promise<DepthDiff[]> {
+  const out: DepthDiff[] = [];
+  for await (const value of iter) out.push(value);
+  return out;
+}
+
+function projectDepth(diff: DepthDiff): unknown {
+  return {
+    ts: diff.ts,
+    bids: diff.bids.map((b) => [b.price, b.qty]),
+    asks: diff.asks.map((a) => [a.price, a.qty]),
+  };
+}
+
+const DEPTH_JSONL = 'packages/io-binance/tests/fixtures/depth.jsonl';
+const DEPTH_ZIP_BASE64 =
+  'UEsDBBQAAAAIAAAAIVDhcvb0RgAAAIgAAAALAAAAZGVwdGguanNvbmyrVnJVsjI0NTe3MDazMAAB' +
+  'HaUkJavoaCVDEEfPQElHyRBIxsbqKCXCxA0h4gZ6pkDxWq5qVDMMUc0whKq1RDMDJm4CNgMAUEsB' +
+  'AhQDFAAAAAgAAAAhUOFy9vRGAAAAiAAAAAsAAAAAAAAAAAAAAIABAAAAAGRlcHRoLmpzb25sUEsF' +
+  'BgAAAAABAAEAOQAAAG8AAAAAAA==';
+
+let tempDir: string | undefined;
+let depthGzPath!: string;
+let depthZipPath!: string;
+
+beforeAll(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'tf-depth-cursor-'));
+  const payload = await readFile(DEPTH_JSONL);
+  depthGzPath = join(tempDir, 'depth.jsonl.gz');
+  await writeFile(depthGzPath, gzipSync(payload));
+  depthZipPath = join(tempDir, 'depth.jsonl.zip');
+  await writeFile(depthZipPath, Buffer.from(DEPTH_ZIP_BASE64, 'base64'));
+});
+
+afterAll(async () => {
+  if (tempDir) {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('depth gz reader resumes from cursor', async () => {
+  const baseline = await collectDepth(
+    createJsonlCursorReader({ kind: 'depth', files: [depthGzPath] }),
+  );
+  const headReader = createJsonlCursorReader({
+    kind: 'depth',
+    files: [depthGzPath],
+  });
+  let cursor = headReader.currentCursor();
+  let count = 0;
+  for await (const _ of headReader) {
+    count += 1;
+    cursor = headReader.currentCursor();
+    if (count === 1) break;
+  }
+  expect(cursor.recordIndex).toBe(1);
+  expect(cursor.file).toBe(depthGzPath);
+
+  const tailReader = createJsonlCursorReader({
+    kind: 'depth',
+    files: [depthGzPath],
+    startCursor: cursor,
+  });
+  const tail = await collectDepth(tailReader);
+  const expectedTail = baseline.slice(cursor.recordIndex);
+  expect(tail.map(projectDepth)).toEqual(expectedTail.map(projectDepth));
+});
+
+test('depth zip reader exposes entry in cursor and resumes', async () => {
+  const baseline = await collectDepth(
+    createJsonlCursorReader({ kind: 'depth', files: [depthZipPath] }),
+  );
+  const headReader = createJsonlCursorReader({
+    kind: 'depth',
+    files: [depthZipPath],
+  });
+  let cursor = headReader.currentCursor();
+  let count = 0;
+  for await (const _ of headReader) {
+    count += 1;
+    cursor = headReader.currentCursor();
+    if (count === 1) break;
+  }
+  expect(cursor.recordIndex).toBe(1);
+  expect(cursor.file).toBe(depthZipPath);
+  expect(cursor.entry).toBe('depth.jsonl');
+
+  const tailReader = createJsonlCursorReader({
+    kind: 'depth',
+    files: [depthZipPath],
+    startCursor: cursor,
+  });
+  const tail = await collectDepth(tailReader);
+  const expectedTail = baseline.slice(cursor.recordIndex);
+  expect(tail.map(projectDepth)).toEqual(expectedTail.map(projectDepth));
+});
+
+test('time filter applies before cursor increment', async () => {
+  const reader = createJsonlCursorReader({
+    kind: 'depth',
+    files: [DEPTH_JSONL],
+    timeFilter: { fromMs: 1577836800100 },
+  });
+  const values = await collectDepth(reader);
+  expect(values).toHaveLength(1);
+  expect(values[0]?.ts).toBe(1577836800100);
+});

--- a/packages/io-binance/tests/jsonl.cursors.trades.test.ts
+++ b/packages/io-binance/tests/jsonl.cursors.trades.test.ts
@@ -1,0 +1,98 @@
+/* eslint-disable */
+import { createJsonlCursorReader } from '../src/index.js';
+import type { Trade } from '@tradeforge/core';
+
+async function collectTrades(iter: AsyncIterable<Trade>): Promise<Trade[]> {
+  const out: Trade[] = [];
+  for await (const value of iter) out.push(value);
+  return out;
+}
+
+function projectTrade(trade: Trade): unknown[] {
+  return [
+    trade.ts,
+    trade.price,
+    trade.qty,
+    trade.side ?? null,
+    trade.id ?? null,
+  ];
+}
+
+const TRADES_FILE = 'packages/io-binance/tests/fixtures/trades.jsonl';
+
+test('jsonl cursor resumes trades stream without gaps', async () => {
+  const fullReader = createJsonlCursorReader({
+    kind: 'trades',
+    files: [TRADES_FILE],
+  });
+  const full = await collectTrades(fullReader);
+
+  const headReader = createJsonlCursorReader({
+    kind: 'trades',
+    files: [TRADES_FILE],
+  });
+  let cursor = headReader.currentCursor();
+  let count = 0;
+  for await (const _ of headReader) {
+    count += 1;
+    cursor = headReader.currentCursor();
+    if (count === 2) break;
+  }
+  expect(cursor.recordIndex).toBe(2);
+  expect(cursor.file).toBe(TRADES_FILE);
+
+  const tailReader = createJsonlCursorReader({
+    kind: 'trades',
+    files: [TRADES_FILE],
+    startCursor: cursor,
+  });
+  const tail = await collectTrades(tailReader);
+  const expectedTail = full.slice(cursor.recordIndex);
+  expect(tail.map(projectTrade)).toEqual(expectedTail.map(projectTrade));
+});
+
+test('startCursor with recordIndex=0 yields full dataset', async () => {
+  const baseline = await collectTrades(
+    createJsonlCursorReader({ kind: 'trades', files: [TRADES_FILE] }),
+  );
+  const resumed = await collectTrades(
+    createJsonlCursorReader({
+      kind: 'trades',
+      files: [TRADES_FILE],
+      startCursor: { file: TRADES_FILE, recordIndex: 0 },
+    }),
+  );
+  expect(resumed.map(projectTrade)).toEqual(baseline.map(projectTrade));
+});
+
+test('startCursor with negative recordIndex throws', () => {
+  expect(() =>
+    createJsonlCursorReader({
+      kind: 'trades',
+      files: [TRADES_FILE],
+      startCursor: { file: TRADES_FILE, recordIndex: -1 },
+    }),
+  ).toThrow(/recordIndex must be >= 0/);
+});
+
+test('unsupported formats are rejected', async () => {
+  await expect(async () => {
+    const reader = createJsonlCursorReader({
+      kind: 'trades',
+      files: ['packages/io-binance/tests/fixtures/trades.csv'],
+    });
+    for await (const _ of reader) {
+      /* noop */
+    }
+  }).rejects.toThrow(/JSONL/);
+
+  await expect(async () => {
+    const reader = createJsonlCursorReader({
+      kind: 'trades',
+      files: ['packages/io-binance/tests/fixtures/trades.json'],
+    });
+    for await (const _ of reader) {
+      /* noop */
+    }
+  }).rejects.toThrow(/JSONL/);
+});


### PR DESCRIPTION
## Summary
- add JSONL cursor reader with cursor-aware iteration for trades and depth plus typed options
- cover cursor resume scenarios for JSONL/GZ/ZIP fixtures with dedicated tests and fixtures
- introduce MergeStartState and optional tie-break override in the merged stream
- generate compressed cursor fixtures during tests instead of committing archives

## Testing
- pnpm -w build
- pnpm -w test
- node -e "(async()=>{const {createJsonlCursorReader}=await import('@tradeforge/io-binance'); const r=createJsonlCursorReader({kind:'trades',files:['packages/io-binance/tests/fixtures/trades.jsonl']}); let i=0; for await(const _ of r){ if(++i===3){ console.log('CUR', r.currentCursor()); break; } } const c=r.currentCursor(); const r2=createJsonlCursorReader({kind:'trades',files:['packages/io-binance/tests/fixtures/trades.jsonl'], startCursor:c}); let k=0; for await(const _ of r2){ k++; } console.log('TAIL', k); })()"

------
https://chatgpt.com/codex/tasks/task_e_68ca681d7d908320b69b9828a8420a52