### PR TITLE
feat(core,cli): replay pause/resume and auto-save checkpoints (simulate flags)

### DIFF
--- a/packages/core/src/replay/clock.ts
+++ b/packages/core/src/replay/clock.ts
@@ -43,7 +43,7 @@ export function createWallClock(): SimClock {
 
 export function createAcceleratedClock(speed: number): SimClock {
   const finiteSpeed = Number.isFinite(speed) ? speed : 1;
-  const normalizedSpeed = finiteSpeed < 0 ? 0 : finiteSpeed;
+  const normalizedSpeed = finiteSpeed <= 0 ? 1 : finiteSpeed;
   const divisor = Math.max(normalizedSpeed, 1e-9);
   return {
     desc(): string {

--- a/packages/core/src/replay/controller.ts
+++ b/packages/core/src/replay/controller.ts
@@ -1,0 +1,57 @@
+import type { ReplayController } from './types.js';
+
+type Deferred = {
+  promise: Promise<void>;
+  resolve: () => void;
+};
+
+function createDeferred(): Deferred {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = () => {
+      res();
+    };
+  });
+  return { promise, resolve };
+}
+
+export function createReplayController(): ReplayController {
+  let paused = false;
+  let deferred: Deferred | undefined;
+
+  function ensureDeferred(): Deferred {
+    if (!deferred) {
+      deferred = createDeferred();
+    }
+    return deferred;
+  }
+
+  function resolveDeferred(): void {
+    if (!deferred) return;
+    const current = deferred;
+    deferred = undefined;
+    current.resolve();
+  }
+
+  return {
+    pause(): void {
+      if (paused) return;
+      paused = true;
+      ensureDeferred();
+    },
+    resume(): void {
+      if (!paused) return;
+      paused = false;
+      resolveDeferred();
+    },
+    isPaused(): boolean {
+      return paused;
+    },
+    waitUntilResumed(): Promise<void> {
+      if (!paused) {
+        return Promise.resolve();
+      }
+      return ensureDeferred().promise;
+    },
+  } satisfies ReplayController;
+}

--- a/packages/core/src/replay/index.ts
+++ b/packages/core/src/replay/index.ts
@@ -1,4 +1,6 @@
 export * from './clock.js';
+export * from './controller.js';
+export * from './runReplay.js';
 export * from './runReplayBasic.js';
 export * from './types.js';
 export * from './checkpoint.js';

--- a/packages/core/src/replay/runReplay.ts
+++ b/packages/core/src/replay/runReplay.ts
@@ -1,0 +1,179 @@
+import { saveCheckpoint } from './checkpoint.js';
+import type { CheckpointV1 } from './checkpoint.js';
+import type {
+  AutoCheckpointOpts,
+  ReplayController,
+  ReplayProgress,
+  RunReplayOptions,
+} from './types.js';
+
+function normalizeEventInterval(value?: number): number | undefined {
+  if (value === undefined) return undefined;
+  if (!Number.isFinite(value)) return undefined;
+  const floored = Math.floor(value);
+  if (floored <= 0) return undefined;
+  return Math.max(1, floored);
+}
+
+function normalizeWallInterval(value?: number): number | undefined {
+  if (value === undefined) return undefined;
+  if (!Number.isFinite(value)) return undefined;
+  return value > 0 ? value : undefined;
+}
+
+function hasAutoCheckpoint(opts?: AutoCheckpointOpts):
+  | (AutoCheckpointOpts & {
+      savePath: string;
+      buildCheckpoint: () => Promise<CheckpointV1>;
+    })
+  | undefined {
+  if (!opts || !opts.savePath || !opts.buildCheckpoint) {
+    return undefined;
+  }
+  return opts as AutoCheckpointOpts & {
+    savePath: string;
+    buildCheckpoint: () => Promise<CheckpointV1>;
+  };
+}
+
+async function waitForResume(controller: ReplayController): Promise<void> {
+  if (!controller.isPaused()) {
+    return;
+  }
+  await controller.waitUntilResumed();
+}
+
+export async function runReplay({
+  timeline,
+  clock,
+  limits,
+  controller,
+  onEvent,
+  onProgress,
+  autoCp,
+}: RunReplayOptions): Promise<ReplayProgress> {
+  const maxEvents = limits?.maxEvents ?? Number.POSITIVE_INFINITY;
+  const maxSimTimeMs = limits?.maxSimTimeMs ?? Number.POSITIVE_INFINITY;
+  const maxWallTimeMs = limits?.maxWallTimeMs ?? Number.POSITIVE_INFINITY;
+  const stats: ReplayProgress = {
+    eventsOut: 0,
+    wallStartMs: clock.now(),
+    wallLastMs: clock.now(),
+  };
+
+  const normalizedAuto = hasAutoCheckpoint(autoCp);
+  const eventInterval = normalizeEventInterval(autoCp?.cpIntervalEvents);
+  const wallInterval = normalizeWallInterval(autoCp?.cpIntervalWallMs);
+  let nextCheckpointByEvents =
+    normalizedAuto && eventInterval !== undefined ? eventInterval : undefined;
+  let nextCheckpointByWall =
+    normalizedAuto && wallInterval !== undefined
+      ? stats.wallStartMs + wallInterval
+      : undefined;
+
+  for await (const event of timeline) {
+    if (stats.eventsOut >= maxEvents) {
+      break;
+    }
+
+    const now = clock.now();
+    stats.wallLastMs = now;
+    if (now - stats.wallStartMs >= maxWallTimeMs) {
+      break;
+    }
+
+    if (
+      stats.simStartTs !== undefined &&
+      stats.simLastTs !== undefined &&
+      Number(stats.simLastTs) - Number(stats.simStartTs) >= maxSimTimeMs
+    ) {
+      break;
+    }
+
+    const simStartValue = stats.simStartTs ?? event.ts;
+    const simElapsed = Math.max(0, Number(event.ts) - Number(simStartValue));
+    const wallTarget = stats.wallStartMs + simElapsed;
+
+    if (wallTarget - stats.wallStartMs > maxWallTimeMs) {
+      break;
+    }
+
+    await clock.tickUntil(wallTarget);
+    stats.wallLastMs = clock.now();
+
+    if (stats.wallLastMs - stats.wallStartMs > maxWallTimeMs) {
+      break;
+    }
+
+    if (controller && controller.isPaused()) {
+      await waitForResume(controller);
+      stats.wallLastMs = clock.now();
+      if (stats.wallLastMs - stats.wallStartMs > maxWallTimeMs) {
+        break;
+      }
+    }
+
+    if (stats.simStartTs === undefined) {
+      stats.simStartTs = simStartValue;
+    }
+    stats.simLastTs = event.ts;
+
+    if (onEvent) {
+      await onEvent(event, stats);
+    }
+
+    stats.eventsOut += 1;
+
+    if (onProgress) {
+      onProgress(stats);
+    }
+
+    if (normalizedAuto) {
+      let savesPlanned = 0;
+      if (
+        nextCheckpointByEvents !== undefined &&
+        eventInterval !== undefined &&
+        stats.eventsOut >= nextCheckpointByEvents
+      ) {
+        savesPlanned = 1;
+        nextCheckpointByEvents += eventInterval;
+      }
+
+      if (nextCheckpointByWall !== undefined && wallInterval !== undefined) {
+        let wallTriggers = 0;
+        while (stats.wallLastMs >= nextCheckpointByWall) {
+          wallTriggers += 1;
+          nextCheckpointByWall += wallInterval;
+        }
+        if (wallTriggers > savesPlanned) {
+          savesPlanned = wallTriggers;
+        }
+      }
+
+      if (savesPlanned > 0) {
+        for (let i = 0; i < savesPlanned; i += 1) {
+          try {
+            const checkpoint = await normalizedAuto.buildCheckpoint();
+            await saveCheckpoint(normalizedAuto.savePath, checkpoint);
+            if (onProgress) {
+              onProgress(stats);
+            }
+          } catch (err) {
+            console.warn(
+              `runReplay: failed to auto-save checkpoint to ${normalizedAuto.savePath}`,
+              err,
+            );
+            break;
+          }
+        }
+        const nowAfterCp = clock.now();
+        if (nowAfterCp > stats.wallLastMs) {
+          stats.wallLastMs = nowAfterCp;
+        }
+      }
+    }
+  }
+
+  stats.wallLastMs = clock.now();
+  return stats;
+}

--- a/packages/core/src/replay/types.ts
+++ b/packages/core/src/replay/types.ts
@@ -1,5 +1,6 @@
 import type { MergedEvent } from '../merge/timeline.js';
 import type { TimestampMs } from '../types/index.js';
+import type { CheckpointV1 } from './checkpoint.js';
 
 export interface SimClock {
   now(): number;
@@ -21,11 +22,37 @@ export interface ReplayStats {
   wallLastMs: number;
 }
 
+export interface ReplayProgress extends ReplayStats {}
+
+export interface ReplayController {
+  pause(): void;
+  resume(): void;
+  isPaused(): boolean;
+  waitUntilResumed(): Promise<void>;
+}
+
+export interface AutoCheckpointOpts {
+  savePath?: string;
+  cpIntervalEvents?: number;
+  cpIntervalWallMs?: number;
+  buildCheckpoint?: () => Promise<CheckpointV1>;
+}
+
 export interface RunReplayBasicOptions {
   timeline: AsyncIterable<MergedEvent>;
   clock: SimClock;
   limits?: ReplayLimits;
   onEvent?: (event: MergedEvent, stats: ReplayStats) => void;
+}
+
+export interface RunReplayOptions {
+  timeline: AsyncIterable<MergedEvent>;
+  clock: SimClock;
+  limits?: ReplayLimits;
+  controller?: ReplayController;
+  onEvent?: (event: MergedEvent, stats: ReplayProgress) => Promise<void> | void;
+  onProgress?: (progress: ReplayProgress) => void;
+  autoCp?: AutoCheckpointOpts;
 }
 
 export type {

--- a/packages/core/tests/replay.autocp.test.ts
+++ b/packages/core/tests/replay.autocp.test.ts
@@ -1,0 +1,232 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as checkpointModule from '../src/replay/checkpoint.js';
+import {
+  runReplay,
+  type CheckpointV1,
+  type MergedEvent,
+  type PriceInt,
+  type QtyInt,
+  type ReplayProgress,
+  type SimClock,
+  type SymbolId,
+  type TimestampMs,
+} from '../src/index';
+
+type AutoProgressLog = number[];
+
+const SYMBOL = 'TEST' as SymbolId;
+const ZERO_PRICE = 0n as PriceInt;
+const ZERO_QTY = 0n as QtyInt;
+
+class ManualClock implements SimClock {
+  #now: number;
+
+  constructor(start = 0) {
+    this.#now = start;
+  }
+
+  desc(): string {
+    return 'manual';
+  }
+
+  now(): number {
+    return this.#now;
+  }
+
+  async tickUntil(target: number): Promise<void> {
+    if (target > this.#now) {
+      this.#now = target;
+    }
+  }
+}
+
+function tradeEvent(ts: number, seq = ts): MergedEvent {
+  const tsMs = ts as TimestampMs;
+  return {
+    kind: 'trade',
+    ts: tsMs,
+    source: 'TRADES',
+    seq,
+    payload: {
+      ts: tsMs,
+      symbol: SYMBOL,
+      price: ZERO_PRICE,
+      qty: ZERO_QTY,
+    },
+  } satisfies MergedEvent;
+}
+
+function timelineFrom(events: MergedEvent[]): AsyncIterable<MergedEvent> {
+  return {
+    async *[Symbol.asyncIterator](): AsyncIterator<MergedEvent> {
+      for (const event of events) {
+        yield event;
+      }
+    },
+  };
+}
+
+function createDummyCheckpoint(): CheckpointV1 {
+  return {
+    version: 1,
+    createdAtMs: Date.now(),
+    meta: { symbol: SYMBOL },
+    cursors: {},
+    merge: {},
+    engine: { openOrderIds: [], stopOrderIds: [] },
+    state: {
+      config: {
+        symbols: {},
+        fee: { makerBps: 0, takerBps: 0 },
+        counters: { accountSeq: 0, orderSeq: 0, tsCounter: 0 },
+      },
+      accounts: {},
+      orders: {},
+    },
+  } satisfies CheckpointV1;
+}
+
+function collectRepeatedProgressValues(logs: AutoProgressLog): number {
+  return logs.reduce((count, value, index) => {
+    if (index === 0) return count;
+    return logs[index - 1] === value ? count + 1 : count;
+  }, 0);
+}
+
+describe('runReplay auto-checkpoints', () => {
+  it('saves checkpoint after configured number of events', async () => {
+    const events = Array.from({ length: 9 }, (_, idx) =>
+      tradeEvent(1_000 + idx * 100, idx + 1),
+    );
+    const tempDir = await mkdtemp(join(tmpdir(), 'tf-autocp-events-'));
+    const savePath = join(tempDir, 'cp.json');
+    const buildSpy = jest.fn(async () => createDummyCheckpoint());
+    const progressLog: AutoProgressLog = [];
+
+    try {
+      const stats = await runReplay({
+        timeline: timelineFrom(events),
+        clock: new ManualClock(0),
+        autoCp: {
+          savePath,
+          cpIntervalEvents: 3,
+          buildCheckpoint: buildSpy,
+        },
+        onProgress: (progress: ReplayProgress) => {
+          progressLog.push(progress.eventsOut);
+        },
+      });
+
+      expect(stats.eventsOut).toBe(events.length);
+      expect(buildSpy).toHaveBeenCalledTimes(3);
+      expect(collectRepeatedProgressValues(progressLog)).toBe(3);
+
+      const raw = await readFile(savePath, 'utf8');
+      const parsed = JSON.parse(raw) as CheckpointV1;
+      expect(parsed.version).toBe(1);
+      expect(parsed.meta.symbol).toBe(String(SYMBOL));
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('saves checkpoint based on wall time interval', async () => {
+    const events = [
+      tradeEvent(1_000, 1),
+      tradeEvent(1_100, 2),
+      tradeEvent(1_300, 3),
+      tradeEvent(1_600, 4),
+      tradeEvent(1_900, 5),
+    ];
+    const tempDir = await mkdtemp(join(tmpdir(), 'tf-autocp-wall-'));
+    const savePath = join(tempDir, 'cp.json');
+    const buildSpy = jest.fn(async () => createDummyCheckpoint());
+
+    try {
+      const stats = await runReplay({
+        timeline: timelineFrom(events),
+        clock: new ManualClock(0),
+        autoCp: {
+          savePath,
+          cpIntervalWallMs: 200,
+          buildCheckpoint: buildSpy,
+        },
+      });
+
+      expect(stats.eventsOut).toBe(events.length);
+      expect(buildSpy).toHaveBeenCalledTimes(4);
+
+      const raw = await readFile(savePath, 'utf8');
+      const parsed = JSON.parse(raw) as CheckpointV1;
+      expect(parsed.meta.symbol).toBe(String(SYMBOL));
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('logs a warning and continues when save fails', async () => {
+    const events = [
+      tradeEvent(1_000, 1),
+      tradeEvent(1_200, 2),
+      tradeEvent(1_400, 3),
+      tradeEvent(1_600, 4),
+    ];
+    const buildSpy = jest.fn(async () => createDummyCheckpoint());
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const saveSpy = jest
+      .spyOn(checkpointModule, 'saveCheckpoint')
+      .mockRejectedValue(new Error('disk full'));
+
+    try {
+      const stats = await runReplay({
+        timeline: timelineFrom(events),
+        clock: new ManualClock(0),
+        autoCp: {
+          savePath: join(tmpdir(), 'should-not-exist.json'),
+          cpIntervalEvents: 2,
+          buildCheckpoint: buildSpy,
+        },
+      });
+
+      expect(stats.eventsOut).toBe(events.length);
+      expect(buildSpy).toHaveBeenCalledTimes(2);
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      saveSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('stops when wall time limit is reached', async () => {
+    const events = Array.from({ length: 6 }, (_, idx) =>
+      tradeEvent(1_000 + idx * 150, idx + 1),
+    );
+    const tempDir = await mkdtemp(join(tmpdir(), 'tf-autocp-limit-'));
+    const savePath = join(tempDir, 'cp.json');
+    const buildSpy = jest.fn(async () => createDummyCheckpoint());
+
+    try {
+      const stats = await runReplay({
+        timeline: timelineFrom(events),
+        clock: new ManualClock(0),
+        limits: { maxWallTimeMs: 350 },
+        autoCp: {
+          savePath,
+          cpIntervalEvents: 2,
+          buildCheckpoint: buildSpy,
+        },
+      });
+
+      expect(stats.eventsOut).toBeLessThan(events.length);
+      expect(buildSpy).toHaveBeenCalledTimes(1);
+
+      const raw = await readFile(savePath, 'utf8');
+      const parsed = JSON.parse(raw) as CheckpointV1;
+      expect(parsed.version).toBe(1);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/tests/replay.controller.test.ts
+++ b/packages/core/tests/replay.controller.test.ts
@@ -1,0 +1,57 @@
+import { createReplayController } from '../src/index';
+
+describe('replay controller', () => {
+  it('pauses on start and resumes on demand', async () => {
+    const controller = createReplayController();
+    expect(controller.isPaused()).toBe(false);
+
+    controller.pause();
+    expect(controller.isPaused()).toBe(true);
+
+    let resolved = false;
+    const waitPromise = controller.waitUntilResumed().then(() => {
+      resolved = true;
+    });
+
+    controller.resume();
+    await waitPromise;
+
+    expect(controller.isPaused()).toBe(false);
+    expect(resolved).toBe(true);
+  });
+
+  it('ignores duplicate pause and resume calls', async () => {
+    const controller = createReplayController();
+
+    controller.pause();
+    controller.pause();
+    expect(controller.isPaused()).toBe(true);
+
+    const firstWait = controller.waitUntilResumed();
+    controller.resume();
+    controller.resume();
+    await expect(firstWait).resolves.toBeUndefined();
+    expect(controller.isPaused()).toBe(false);
+
+    controller.resume();
+    expect(controller.isPaused()).toBe(false);
+    await expect(controller.waitUntilResumed()).resolves.toBeUndefined();
+  });
+
+  it('supports multiple pause/resume cycles', async () => {
+    const controller = createReplayController();
+
+    controller.pause();
+    const firstWait = controller.waitUntilResumed();
+    controller.resume();
+    await firstWait;
+    expect(controller.isPaused()).toBe(false);
+
+    controller.pause();
+    expect(controller.isPaused()).toBe(true);
+    const secondWait = controller.waitUntilResumed();
+    controller.resume();
+    await secondWait;
+    expect(controller.isPaused()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- implement a replay controller with pause/resume coordination and expose it via the core replay exports
- add a full-featured `runReplay` that supports pause handling, auto-checkpoint intervals, and dedicated unit/integration tests
- update the CLI `simulate` command with pause/autosave flags, checkpoint builder wiring, and progress logging

## Testing
- pnpm -w build
- pnpm -w test
- pnpm --filter @tradeforge/cli dev -- simulate --trades packages/io-binance/tests/fixtures/trades.jsonl --clock accel --speed 10 --checkpoint-save /tmp/tf.cp.json --cp-interval-events 3
- pnpm --filter @tradeforge/cli dev -- simulate --trades packages/io-binance/tests/fixtures/trades.jsonl --clock wall --max-wall-ms 8000 --checkpoint-save /tmp/tf.cp.wall.json --cp-interval-wall-ms 400 --pause-on-start

------
https://chatgpt.com/codex/tasks/task_e_68ca89b83d8883208c7efc0761563a7d