### PR TITLE
docs(cli,svc,guide): уточнение --summary/NDJSON, пример ответа /v1/orders, диаграмма потока

### DIFF
--- a/apps/svc/README.md
+++ b/apps/svc/README.md
@@ -107,6 +107,35 @@ curl -X POST http://localhost:3000/v1/orders \
 # }
 ```
 
+Числовые значения — строки (fixed-point). Поля и точный формат зависят от текущей версии API.
+
+```json
+{
+  "id": "O1",
+  "tsCreated": 1,
+  "tsUpdated": 1,
+  "symbol": "BTCUSDT",
+  "type": "LIMIT",
+  "side": "BUY",
+  "tif": "GTC",
+  "qty": "10000",
+  "status": "OPEN",
+  "accountId": "A1",
+  "executedQty": "0",
+  "cumulativeQuote": "0",
+  "fees": {},
+  "fills": [],
+  "price": "2500000000",
+  "reserved": {
+    "currency": "USDT",
+    "total": "25012500",
+    "remaining": "25012500"
+  }
+}
+```
+
+`tsCreated`/`tsUpdated` — миллисекунды Unix (в чистом запуске используются логические тики, при живых данных будут значения из таймлайна).
+
 ```bash
 curl -i -X POST http://localhost:3000/v1/orders \
   -H 'Content-Type: application/json' \


### PR DESCRIPTION
## Summary
- add a quickstart summary example and describe `--summary`/`--ndjson` outputs in the CLI guide
- document a representative POST `/v1/orders` success payload in the service README with timestamp notes
- include a mermaid data-flow diagram linking inputs, engine, checkpoints and outputs in the general guide

## Testing
- `pnpm -w build`
- `node apps/cli/dist/apps/cli/src/index.js simulate --help`

## Checklist
- [x] apps/cli/README.md: раздел Summary/NDJSON и пример вывода
- [x] apps/svc/README.md: полный пример успешного ответа POST /v1/orders
- [x] docs/guide.md: mermaid-диаграмма потока
- [x] CI зелёный


------
https://chatgpt.com/codex/tasks/task_e_68cab528d35c8320aa3a064f0b9d5f76