### PR TITLE
fix(core): validateCheckpointPayload checks all fields + add negative cursor tests

### DIFF
--- a/packages/core/tests/checkpoint.errors.test.ts
+++ b/packages/core/tests/checkpoint.errors.test.ts
@@ -88,6 +88,27 @@ test('loadCheckpoint rejects negative cursor recordIndex', async () => {
   });
 });
 
+test('loadCheckpoint rejects depth cursor when recordIndex is negative', async () => {
+  const base = createCheckpointPayload();
+  base.cursors.trades = { file: 'trades.jsonl', recordIndex: 0 };
+  base.cursors.depth = { file: 'depth.jsonl', recordIndex: -1 };
+  await withCheckpointFile(base, async (filePath) => {
+    await expect(loadCheckpoint(filePath)).rejects.toThrow('recordIndex');
+  });
+});
+
+test('loadCheckpoint rejects cursor when entry is not a string', async () => {
+  const base = createCheckpointPayload();
+  base.cursors.depth = {
+    file: 'depth.jsonl',
+    recordIndex: 0,
+    entry: 42 as unknown as string,
+  };
+  await withCheckpointFile(base, async (filePath) => {
+    await expect(loadCheckpoint(filePath)).rejects.toThrow('entry');
+  });
+});
+
 test('deserializeExchangeState rejects unknown currencies', () => {
   const serialized: SerializedExchangeState = {
     ...createSerializedState(),


### PR DESCRIPTION
## Summary
- ensure `validateCheckpointPayload` validates createdAtMs, meta note, cursor entries, engine order ID arrays, and state objects before returning
- add helper to verify string arrays and expand checkpoint error tests with additional invalid cursor cases

## Testing
- pnpm -w build
- pnpm -w test

## Checklist
- [x] validateCheckpointPayload исправлен
- [x] createdAtMs проверяется
- [x] Тесты на курсоры с invalid recordIndex и entry
- [x] CI зелёный

------
https://chatgpt.com/codex/tasks/task_e_68cab0391b908320a06ce222a1581b39