### PR TITLE
docs(cli,svc,guide): пояснения summary-полей, пример ошибки рядом с успешным ответом, приписка про conservative model

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -78,6 +78,11 @@ pnpm --filter @tradeforge/cli exec -- tf --version
    }
    ```
 
+   Ключевые поля в агрегированной сводке:
+   - `eventsProcessed` — число обработанных событий;
+   - `fills` — количество исполненных сделок по ордерам пользователя;
+   - `totalFees` — суммарные комиссии (строка).
+
 ## Supported formats
 
 - Симулятор читает CSV, JSON и JSONL (`*.jsonl`, `*.jsonl.gz`, `*.jsonl.zip`).

--- a/apps/svc/README.md
+++ b/apps/svc/README.md
@@ -107,6 +107,25 @@ curl -X POST http://localhost:3000/v1/orders \
 # }
 ```
 
+При нарушении валидации сервер вернёт `HTTP/1.1 400 Bad Request`. Например, если для `LIMIT` не передать `price`:
+
+```bash
+curl -i -X POST http://localhost:3000/v1/orders \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "accountId": "a1",
+    "symbol": "BTCUSDT",
+    "type": "LIMIT",
+    "side": "BUY",
+    "qty": "0.01"
+  }'
+# HTTP/1.1 400 Bad Request
+```
+
+```json
+{ "message": "price is required for LIMIT" }
+```
+
 Числовые значения — строки (fixed-point). Поля и точный формат зависят от текущей версии API.
 
 ```json
@@ -135,20 +154,6 @@ curl -X POST http://localhost:3000/v1/orders \
 ```
 
 `tsCreated`/`tsUpdated` — миллисекунды Unix (в чистом запуске используются логические тики, при живых данных будут значения из таймлайна).
-
-```bash
-curl -i -X POST http://localhost:3000/v1/orders \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "accountId": "a1",
-    "symbol": "BTCUSDT",
-    "type": "LIMIT",
-    "side": "BUY",
-    "qty": "0.01"
-  }'
-# HTTP/1.1 400 Bad Request
-# {"message":"price is required for LIMIT"}
-```
 
 #### STOP_LIMIT / STOP_MARKET
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -21,6 +21,8 @@ flowchart LR
   D --> G[CLI/REST outputs (summary/NDJSON, responses)]
 ```
 
+Диаграмма отражает conservative execution model (MVP-1), где исполнение идёт только по TRADES. В будущих версиях появится режим full-conformance, учитывающий влияние ордеров на поток и глубину ордербука.
+
 - **Binance historical files** — исходные сделки и стаканы Binance (обычно `*.jsonl`), которые выступают единым источником правды.
 - **Readers** — адаптеры `@tradeforge/io-binance`, формирующие восстановимые JSONL-стримы с курсорами.
 - **Deterministic merge** — объединитель событий `createMergedStream`, решающий конфликты по типу и тай-брейку.


### PR DESCRIPTION
## Summary
- уточнены поля агрегированного summary в CLI README прямо под примером вывода
- добавлен пример ответа с HTTP 400 для LIMIT без price рядом с успешным POST /v1/orders
- помечено в guide, что диаграмма описывает conservative execution model MVP-1 и упомянут будущий full-conformance режим

## Testing
- `pnpm -w build`


------
https://chatgpt.com/codex/tasks/task_e_68cabc9b02008320bf02666d02260ebe