### PR TITLE
chore(core): stricter checkpoint validation (non-empty strings, integer createdAtMs)

### DIFF
--- a/packages/core/src/replay/checkpoint.ts
+++ b/packages/core/src/replay/checkpoint.ts
@@ -590,6 +590,14 @@ function ensureString(value: unknown, path: string): string {
   return value;
 }
 
+function ensureNonEmptyString(value: unknown, path: string): string {
+  const str = ensureString(value, path);
+  if (str.trim().length === 0) {
+    throw new Error(`checkpoint ${path} must be a non-empty string`);
+  }
+  return str;
+}
+
 function ensureNumber(value: unknown, path: string): number {
   if (value === undefined || value === null) {
     throw new Error(`checkpoint is missing required field: ${path}`);
@@ -626,7 +634,7 @@ function ensureStringArray(value: unknown, path: string): string[] {
 
 function validateCursor(name: string, value: unknown): void {
   const cursor = ensureObject(value, `cursors.${name}`);
-  ensureString(cursor['file'], `cursors.${name}.file`);
+  ensureNonEmptyString(cursor['file'], `cursors.${name}.file`);
   const entry = cursor['entry'];
   if (entry !== undefined && typeof entry !== 'string') {
     throw new Error(`checkpoint cursors.${name}.entry must be a string`);
@@ -649,7 +657,7 @@ function validateCheckpointPayload(data: unknown): CheckpointV1 {
     throw new Error('unsupported checkpoint version');
   }
   const meta = ensureObject(parsed['meta'], 'meta');
-  ensureString(meta['symbol'], 'meta.symbol');
+  ensureNonEmptyString(meta['symbol'], 'meta.symbol');
   const createdAtMs = ensureNumber(parsed['createdAtMs'], 'createdAtMs');
   if (!Number.isInteger(createdAtMs)) {
     throw new Error('checkpoint createdAtMs must be an integer');

--- a/packages/core/tests/checkpoint.errors.test.ts
+++ b/packages/core/tests/checkpoint.errors.test.ts
@@ -67,6 +67,16 @@ test('loadCheckpoint rejects unsupported version', async () => {
   });
 });
 
+test('loadCheckpoint rejects non-integer createdAtMs', async () => {
+  const base = createCheckpointPayload();
+  base.createdAtMs = 1.23;
+  await withCheckpointFile(base, async (filePath) => {
+    await expect(loadCheckpoint(filePath)).rejects.toThrow(
+      'checkpoint createdAtMs must be an integer',
+    );
+  });
+});
+
 test('loadCheckpoint requires state field to be present', async () => {
   const base = createCheckpointPayload();
   const invalid = { ...base } as Record<string, unknown>;
@@ -106,6 +116,14 @@ test('loadCheckpoint rejects cursor when entry is not a string', async () => {
   };
   await withCheckpointFile(base, async (filePath) => {
     await expect(loadCheckpoint(filePath)).rejects.toThrow('entry');
+  });
+});
+
+test('loadCheckpoint rejects cursor with empty file name', async () => {
+  const base = createCheckpointPayload();
+  base.cursors.trades = { file: '', recordIndex: 0 };
+  await withCheckpointFile(base, async (filePath) => {
+    await expect(loadCheckpoint(filePath)).rejects.toThrow(/non-empty/);
   });
 });
 


### PR DESCRIPTION
## Summary
- add an `ensureNonEmptyString` helper to checkpoint validation to reject empty meta symbols and cursor file names
- ensure checkpoints reject non-integer `createdAtMs` values
- cover empty file and fractional timestamp scenarios with new error tests

## Testing
- pnpm -w build
- pnpm -w test

------
https://chatgpt.com/codex/tasks/task_e_68cabe0cdad083209b571e6fd0055e74