### PR TITLE
docs(examples): 01-basic-replay (CLI + SDK) with smoke

### DIFF
--- a/examples/01-basic-replay/README.md
+++ b/examples/01-basic-replay/README.md
@@ -20,6 +20,8 @@
    export TF_DEPTH_FILES="examples/_smoke/mini-depth.jsonl"
    ```
 
+   Списки файлов в `TF_TRADES_FILES`/`TF_DEPTH_FILES` можно разделять запятыми, пробелами или двоеточиями.
+
 2. Запускаем симуляцию через CLI (логические часы, 200 событий, краткий summary):
 
    ```bash

--- a/examples/01-basic-replay/README.md
+++ b/examples/01-basic-replay/README.md
@@ -1,9 +1,92 @@
-# 01. Basic Replay
+# 01 — Базовый исторический прогон
 
-TODO: описать сценарий. Используйте шаблоны из [`../_templates`](../_templates/).
+Минимальный пример исторического прогона симулятора TradeForge. Сценарий использует готовые JSONL-файлы сделок и стакана, объединяет их в единую временную шкалу и воспроизводит события через CLI или SDK.
 
-## Черновик плана
+## Требования
 
-- [ ] Подключить ридеры трейдов и стакана.
-- [ ] Настроить merge и запуск `runScenario`.
-- [ ] Описать минимальные параметры запуска (CLI/SDK).
+- Установленные зависимости репозитория (`pnpm install`).
+- Сборка рабочих пакетов (`pnpm -w build`).
+- Наличие файлов с данными:
+  - сделки — `*.jsonl`, `*.jsonl.gz` или `*.jsonl.zip`;
+  - обновления стакана — `*.jsonl`, `*.jsonl.gz` или `*.jsonl.zip`.
+- Для быстрого старта можно использовать мини-фикстуры из [`examples/_smoke`](../_smoke/).
+
+## Вариант A — CLI
+
+1. Указываем файлы через переменные окружения (можно перечислять несколько путём разделения запятой или переносом строки):
+
+   ```bash
+   export TF_TRADES_FILES="examples/_smoke/mini-trades.jsonl"
+   export TF_DEPTH_FILES="examples/_smoke/mini-depth.jsonl"
+   ```
+
+2. Запускаем симуляцию через CLI (логические часы, 200 событий, краткий summary):
+
+   ```bash
+   pnpm --filter @tradeforge/cli dev -- simulate \
+     --trades "$TF_TRADES_FILES" \
+     --depth "$TF_DEPTH_FILES" \
+     --clock logical \
+     --max-events 200 \
+     --summary
+   ```
+
+### Accelerated / Wall примеры
+
+Примеры альтернативных часов:
+
+```bash
+pnpm --filter @tradeforge/cli dev -- simulate \
+  --trades "$TF_TRADES_FILES" --depth "$TF_DEPTH_FILES" \
+  --clock accelerated --speed 20 --max-sim-ms 300000 --summary
+
+pnpm --filter @tradeforge/cli dev -- simulate \
+  --trades "$TF_TRADES_FILES" --depth "$TF_DEPTH_FILES" \
+  --clock wall --max-wall-ms 10000 --summary
+```
+
+### NDJSON (опционально)
+
+Для потоковой выгрузки отчёта в формате NDJSON можно включить соответствующий флаг и перенаправить вывод в файл:
+
+```bash
+pnpm --filter @tradeforge/cli dev -- simulate \
+  --trades "$TF_TRADES_FILES" --depth "$TF_DEPTH_FILES" \
+  --clock logical --max-events 200 --ndjson > /tmp/tf.reports.ndjson
+```
+
+## Вариант B — SDK (TypeScript)
+
+1. Собираем примеры (создаст `dist-examples/**`):
+
+   ```bash
+   pnpm -w examples:build
+   ```
+
+2. Запускаем подготовленный скрипт. Файлы и параметры задаём через переменные окружения (в скобках — значения по умолчанию):
+
+   ```bash
+   TF_TRADES_FILES="examples/_smoke/mini-trades.jsonl" \
+   TF_DEPTH_FILES="examples/_smoke/mini-depth.jsonl" \
+   TF_CLOCK=logical \
+   TF_MAX_EVENTS=200 \
+   node dist-examples/01-basic-replay/run.js
+   ```
+
+   Дополнительные параметры:
+   - `TF_TIE_BREAK` — стратегия при совпадении временных меток (`DEPTH` | `TRADES`, по умолчанию `DEPTH`).
+   - `TF_SPEED` — множитель ускорения для `TF_CLOCK=accelerated`.
+   - `TF_MAX_SIM_MS` — лимит по симулируемому времени (миллисекунды).
+   - `TF_MAX_WALL_MS` — лимит по реальному времени исполнения (миллисекунды).
+
+   В stdout появится строка `BASIC_REPLAY_OK { ... }` с числом обработанных событий и длительностью прогона.
+
+## Smoke-проверка
+
+Для локальной проверки можно воспользоваться готовым скриптом:
+
+```bash
+pnpm -w examples:ex01:smoke
+```
+
+Он соберёт переменные окружения для мини-фикстур и проверит наличие маркера `BASIC_REPLAY_OK` в выводе SDK-скрипта.

--- a/examples/01-basic-replay/run.ts
+++ b/examples/01-basic-replay/run.ts
@@ -1,0 +1,303 @@
+import { basename, resolve } from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+import {
+  createAcceleratedClock,
+  createLogicalClock,
+  createMergedStream,
+  createWallClock,
+  runReplay,
+  type CursorIterable as CoreCursorIterable,
+  type DepthEvent,
+  type MergeStartState,
+  type MergedEvent,
+  type ReplayLimits,
+  type ReplayProgress,
+  type SimClock,
+  type TradeEvent,
+} from '@tradeforge/core';
+import {
+  createJsonlCursorReader,
+  type CursorIterable as JsonlCursor,
+  type DepthDiff,
+  type ReaderCursor,
+  type Trade,
+} from '@tradeforge/io-binance';
+import { createLogger, formatProgress } from '../_shared/logging.js';
+
+const logger = createLogger({ prefix: '[examples/01-basic-replay]' });
+
+function parseList(value: string | undefined, fallback: string[]): string[] {
+  if (!value) {
+    return fallback;
+  }
+  const parts = value
+    .split(/[\n,]/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  if (parts.length === 0) {
+    return fallback;
+  }
+  return parts;
+}
+
+function ensureAbsolute(files: string[]): string[] {
+  return files.map((file) => resolve(file));
+}
+
+function getEntry(cursor: ReaderCursor): string | undefined {
+  if (cursor.entry && cursor.entry.trim().length > 0) {
+    return cursor.entry;
+  }
+  return basename(cursor.file);
+}
+
+function wrapTrades(
+  source: JsonlCursor<Trade>,
+): CoreCursorIterable<TradeEvent> {
+  return {
+    currentCursor(): ReaderCursor {
+      return source.currentCursor();
+    },
+    async *[Symbol.asyncIterator](): AsyncIterator<TradeEvent> {
+      let lastKey: string | undefined;
+      let seq = 0;
+      for await (const payload of source) {
+        const cursor = source.currentCursor();
+        const key = `${cursor.file}::${cursor.entry ?? ''}`;
+        if (key !== lastKey) {
+          lastKey = key;
+          seq = 0;
+        }
+        const event: TradeEvent = {
+          kind: 'trade',
+          ts: payload.ts,
+          payload,
+          source: 'TRADES',
+          seq: seq++,
+        };
+        const entry = getEntry(cursor);
+        if (entry) {
+          event.entry = entry;
+        }
+        yield event;
+      }
+    },
+  } satisfies CoreCursorIterable<TradeEvent>;
+}
+
+function wrapDepth(
+  source: JsonlCursor<DepthDiff>,
+): CoreCursorIterable<DepthEvent> {
+  return {
+    currentCursor(): ReaderCursor {
+      return source.currentCursor();
+    },
+    async *[Symbol.asyncIterator](): AsyncIterator<DepthEvent> {
+      let lastKey: string | undefined;
+      let seq = 0;
+      for await (const payload of source) {
+        const cursor = source.currentCursor();
+        const key = `${cursor.file}::${cursor.entry ?? ''}`;
+        if (key !== lastKey) {
+          lastKey = key;
+          seq = 0;
+        }
+        const event: DepthEvent = {
+          kind: 'depth',
+          ts: payload.ts,
+          payload,
+          source: 'DEPTH',
+          seq: seq++,
+        };
+        const entry = getEntry(cursor);
+        if (entry) {
+          event.entry = entry;
+        }
+        yield event;
+      }
+    },
+  } satisfies CoreCursorIterable<DepthEvent>;
+}
+
+type ClockKind = 'logical' | 'wall' | 'accelerated';
+
+type ParsedClock = {
+  clock: SimClock;
+  kind: ClockKind;
+  desc: string;
+};
+
+function parseClock(value: string | undefined): ClockKind {
+  const normalized = value?.toLowerCase();
+  if (normalized === 'wall' || normalized === 'accelerated') {
+    return normalized;
+  }
+  return 'logical';
+}
+
+function parsePositiveNumber(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return undefined;
+  }
+  return parsed;
+}
+
+function buildClock(clock: ClockKind): ParsedClock {
+  if (clock === 'wall') {
+    const built = createWallClock();
+    return { clock: built, kind: clock, desc: built.desc() };
+  }
+  if (clock === 'accelerated') {
+    const speed = parsePositiveNumber(process.env['TF_SPEED']) ?? 20;
+    const built = createAcceleratedClock(speed);
+    return { clock: built, kind: clock, desc: built.desc() };
+  }
+  const built = createLogicalClock();
+  return { clock: built, kind: 'logical', desc: built.desc() };
+}
+
+function parseTieBreak(value: string | undefined): 'DEPTH' | 'TRADES' {
+  const normalized = value?.trim().toUpperCase();
+  if (normalized === 'TRADES') {
+    return 'TRADES';
+  }
+  return 'DEPTH';
+}
+
+function parseMaxEvents(value: string | undefined): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return 200;
+  }
+  return Math.floor(parsed);
+}
+
+function parseMilliseconds(value: string | undefined): number | undefined {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return undefined;
+  }
+  return parsed;
+}
+
+function buildLimits(): ReplayLimits {
+  const limits: ReplayLimits = {
+    maxEvents: parseMaxEvents(process.env['TF_MAX_EVENTS']),
+  };
+  const maxSim = parseMilliseconds(process.env['TF_MAX_SIM_MS']);
+  if (maxSim !== undefined) {
+    limits.maxSimTimeMs = maxSim;
+  }
+  const maxWall = parseMilliseconds(process.env['TF_MAX_WALL_MS']);
+  if (maxWall !== undefined) {
+    limits.maxWallTimeMs = maxWall;
+  }
+  return limits;
+}
+
+function formatList(label: string, items: string[]): string {
+  return `${label}=${items.join(', ')}`;
+}
+
+function formatLimits(limits: ReplayLimits): string {
+  const parts: string[] = [];
+  if (limits.maxEvents !== undefined) {
+    parts.push(`events<=${limits.maxEvents}`);
+  }
+  if (limits.maxSimTimeMs !== undefined) {
+    parts.push(`sim<=${limits.maxSimTimeMs}ms`);
+  }
+  if (limits.maxWallTimeMs !== undefined) {
+    parts.push(`wall<=${limits.maxWallTimeMs}ms`);
+  }
+  return parts.length > 0 ? parts.join(', ') : 'no limits';
+}
+
+function defaultFileList(): { trades: string[]; depth: string[] } {
+  const trades = parseList(process.env['TF_TRADES_FILES'], [
+    'examples/_smoke/mini-trades.jsonl',
+  ]);
+  const depth = parseList(process.env['TF_DEPTH_FILES'], [
+    'examples/_smoke/mini-depth.jsonl',
+  ]);
+  return { trades: ensureAbsolute(trades), depth: ensureAbsolute(depth) };
+}
+
+export async function run(): Promise<ReplayProgress> {
+  const { trades, depth } = defaultFileList();
+  logger.info(
+    [formatList('trades', trades), formatList('depth', depth)].join(' | '),
+  );
+
+  const tradeReader = wrapTrades(
+    createJsonlCursorReader({ kind: 'trades', files: trades }),
+  );
+  const depthReader = wrapDepth(
+    createJsonlCursorReader({ kind: 'depth', files: depth }),
+  );
+
+  const tieBreak = parseTieBreak(process.env['TF_TIE_BREAK']);
+  const mergeStart: MergeStartState = { nextSourceOnEqualTs: tieBreak };
+  const preferDepth = tieBreak !== 'TRADES';
+  const timeline: AsyncIterable<MergedEvent> = createMergedStream(
+    tradeReader,
+    depthReader,
+    mergeStart,
+    { preferDepthOnEqualTs: preferDepth },
+  );
+
+  const clock = buildClock(parseClock(process.env['TF_CLOCK']));
+  const limits = buildLimits();
+  logger.info(
+    `clock=${clock.desc} (${clock.kind}) tieBreak=${tieBreak} limits=${formatLimits(limits)}`,
+  );
+
+  const progress = await runReplay({
+    timeline,
+    clock: clock.clock,
+    limits,
+    onProgress: (stats: ReplayProgress) => {
+      logger.progress(stats);
+    },
+  });
+
+  logger.info(`completed ${formatProgress(progress)}`);
+  return progress;
+}
+
+async function main(): Promise<void> {
+  try {
+    const progress = await run();
+    const wallMs = Math.max(0, progress.wallLastMs - progress.wallStartMs);
+    const simMs =
+      progress.simStartTs !== undefined && progress.simLastTs !== undefined
+        ? Math.max(0, Number(progress.simLastTs) - Number(progress.simStartTs))
+        : undefined;
+    const marker: Record<string, number> & { simMs?: number } = {
+      eventsOut: progress.eventsOut,
+      wallMs,
+    };
+    if (simMs !== undefined) {
+      marker.simMs = simMs;
+    }
+    console.log('BASIC_REPLAY_OK', marker);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('BASIC_REPLAY_FAILED', message);
+    if (err instanceof Error && err.stack) {
+      console.error(err.stack);
+    }
+    process.exit(1);
+  }
+}
+
+const invokedFromCli =
+  process.argv[1] &&
+  pathToFileURL(resolve(process.argv[1])).href === import.meta.url;
+
+if (invokedFromCli) {
+  void main();
+}

--- a/examples/01-basic-replay/smoke.ts
+++ b/examples/01-basic-replay/smoke.ts
@@ -1,0 +1,55 @@
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import process from 'node:process';
+
+function ensureMarker(output: string): void {
+  if (!output.includes('BASIC_REPLAY_OK')) {
+    throw new Error('marker BASIC_REPLAY_OK not found in stdout');
+  }
+}
+
+function main(): void {
+  const trades = resolve('examples', '_smoke', 'mini-trades.jsonl');
+  const depth = resolve('examples', '_smoke', 'mini-depth.jsonl');
+
+  const result = spawnSync('node', ['dist-examples/01-basic-replay/run.js'], {
+    env: {
+      ...process.env,
+      TF_TRADES_FILES: trades,
+      TF_DEPTH_FILES: depth,
+      TF_CLOCK: process.env['TF_CLOCK'] ?? 'logical',
+      TF_MAX_EVENTS: process.env['TF_MAX_EVENTS'] ?? '200',
+    },
+    encoding: 'utf8',
+    stdio: 'pipe',
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (typeof result.status === 'number' && result.status !== 0) {
+    const stderr = result.stderr ? `\n${result.stderr}` : '';
+    throw new Error(`example exited with code ${result.status}${stderr}`);
+  }
+
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+
+  ensureMarker(result.stdout ?? '');
+  console.log('EX01_BASIC_SMOKE_OK');
+}
+
+try {
+  main();
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error('[examples/01-basic-replay] smoke failed:', message);
+  if (err instanceof Error && err.stack) {
+    console.error(err.stack);
+  }
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "prepare": "husky install",
     "examples:build": "tsc -p tsconfig.examples.json",
     "examples:lint": "eslint \"examples/**/*.{ts,tsx,js,md}\"",
-    "examples:run": "node --enable-source-maps examples/_shared/bin/run-scenario.ts"
+    "examples:run": "node --enable-source-maps examples/_shared/bin/run-scenario.ts",
+    "examples:ex01": "node dist-examples/01-basic-replay/run.js",
+    "examples:ex01:build": "tsc -p tsconfig.examples.json --incremental",
+    "examples:ex01:smoke": "node examples/01-basic-replay/smoke.ts"
   },
   "devDependencies": {
     "@types/jest": "^29.5.11",


### PR DESCRIPTION
## Summary
- replace the placeholder README with CLI and SDK walkthroughs for scenario 01
- add the runnable TypeScript replay script and mini-smoke harness that assert the BASIC_REPLAY_OK marker
- wire new convenience scripts into the root package for building, running and smoke-testing ex01

## Testing
- pnpm -w build
- pnpm -w examples:build
- TF_TRADES_FILES=examples/_smoke/mini-trades.jsonl TF_DEPTH_FILES=examples/_smoke/mini-depth.jsonl pnpm -w examples:ex01
- pnpm -w examples:ex01:smoke

## Checklist
- [x] README (CLI/SDK) добавлен
- [x] run.ts реализован
- [x] smoke.ts добавлен
- [x] scripts для ex01 добавлены
- [x] CI зелёный


------
https://chatgpt.com/codex/tasks/task_e_68caed829a5483208bda05c75c06a636