### PR TITLE
docs(examples): 03-accounts-and-orders (CLI + SDK + REST)

### DIFF
--- a/examples/03-accounts-and-orders/README.md
+++ b/examples/03-accounts-and-orders/README.md
@@ -1,9 +1,109 @@
-# 03. Accounts and Orders
+# 03 — Аккаунты и LIMIT-ордера
 
-TODO: описать сценарий работы с аккаунтами и базовыми ордерами.
+Пример объединяет работу с аккаунтами и лимитными ордерами в TradeForge. Сценарий создаёт счёт, вносит депозит в котируемой валюте, выставляет пару LIMIT-ордеров (BUY и SELL), дожидается исполнения сделками из исторической ленты и отменяет оставшийся «висящий» ордер. В конце выводятся балансы и счётчик открытых заявок.
 
-## Черновик плана
+## Требования
 
-- [ ] Использовать `_shared/accounts.ts` для создания аккаунтов.
-- [ ] Показать пример выставления ордеров и проверки балансов.
-- [ ] Задокументировать шаги CLI/SDK.
+- Установленные зависимости (`pnpm install`).
+- Сборка пакетов (`pnpm -w build`).
+- Сборка примеров (`pnpm -w examples:build`) — создаёт `dist-examples/**`.
+- Источник данных: JSONL-файлы сделок и стакана. Для быстрого старта можно использовать мини-набор из [`examples/_smoke`](../_smoke/).
+
+## CLI — запуск готового сценария
+
+1. Указываем файлы сделок и стакана (можно перечислять несколько путём разделения запятой или переносом строки):
+
+   ```bash
+   export TF_TRADES_FILES="examples/_smoke/mini-trades.jsonl"
+   export TF_DEPTH_FILES="examples/_smoke/mini-depth.jsonl"
+   ```
+
+   Если переменные не заданы, скрипт по умолчанию возьмёт именно эти мини-файлы.
+
+2. Собираем примеры (если ещё не собраны) и запускаем CLI-обёртку:
+
+   ```bash
+   pnpm -w examples:build
+   pnpm examples:run 03-accounts-and-orders
+   ```
+
+   В stdout появятся журнальные сообщения и итоговая строка-маркер:
+
+   ```text
+   ACC_ORDERS_OK { balances: { BTC: { free: '0.015000', locked: '0' }, USDT: { free: '59.43875', locked: '0' } }, openOrdersCount: 0 }
+   ```
+
+   `ACC_ORDERS_OK` используется смоуком и автоматизацией для проверки успешного прохождения сценария.
+
+## SDK (TypeScript) — основные шаги
+
+В файле [`run.ts`](./run.ts) показан полный сценарий на SDK:
+
+1. Считывание сделок/стакана через `buildTradesReader` и `buildDepthReader`, объединение в единый поток `buildMerged`.
+2. Инициализация `ExchangeState`, `AccountsService` и `OrdersService`.
+3. Создание аккаунта с депозитом 1000 USDT через `createAccountWithDeposit` (строка "1000" автоматически конвертируется в целое число с учётом `priceScale`).
+4. Размещение ордера `LIMIT BUY 0.030 BTC @ 27000.40`, отслеживание заполнения через `executeTimeline`.
+5. После частичного/полного заполнения BUY-ордера — размещение `LIMIT SELL` на часть полученного базового актива и дополнительного «висящего» `LIMIT BUY`, который затем отменяется.
+6. Финальный снимок балансов (`getBalancesSnapshot`) и подсчёт активных заявок (`listOpenOrders`).
+
+Запуск собранного скрипта напрямую (переменные окружения аналогичны CLI-варианту):
+
+```bash
+TF_TRADES_FILES="examples/_smoke/mini-trades.jsonl" \
+TF_DEPTH_FILES="examples/_smoke/mini-depth.jsonl" \
+node dist-examples/03-accounts-and-orders/run.js
+```
+
+Скрипт завершится выводом маркера `ACC_ORDERS_OK` с балансовой сводкой. Все числа в логах конвертируются обратно в человекочитаемый формат (`fromPriceInt`/`fromQtyInt`).
+
+## REST (curl)
+
+Для работы HTTP API поднимаем сервис:
+
+```bash
+pnpm --filter @tradeforge/svc dev
+```
+
+По умолчанию сервер слушает `http://localhost:3000`. Все числовые поля (`amount`, `qty`, `price`) передаются строками в десятичном формате — сервер сам преобразует их в фиксированную точность по конфигурации символа.
+
+### Создание аккаунта и депозит
+
+```bash
+ACCOUNT_ID=$(curl -s -X POST http://localhost:3000/v1/accounts | jq -r '.accountId')
+
+curl -s -X POST "http://localhost:3000/v1/accounts/$ACCOUNT_ID/deposit" \
+  -H 'content-type: application/json' \
+  -d '{"currency":"USDT","amount":"1000"}'
+```
+
+### Размещение LIMIT-ордера
+
+```bash
+ORDER_JSON=$(curl -s -X POST http://localhost:3000/v1/orders \
+  -H 'content-type: application/json' \
+  -d '{
+        "accountId": "'"$ACCOUNT_ID"'",
+        "symbol": "BTCUSDT",
+        "type": "LIMIT",
+        "side": "BUY",
+        "qty": "0.030",
+        "price": "27000.40"
+      }')
+ORDER_ID=$(echo "$ORDER_JSON" | jq -r '.id')
+```
+
+Проверяем статус ордера и текущие балансы:
+
+```bash
+curl -s "http://localhost:3000/v1/orders/$ORDER_ID" | jq
+curl -s "http://localhost:3000/v1/accounts/$ACCOUNT_ID/balances" | jq
+curl -s "http://localhost:3000/v1/orders/open?accountId=$ACCOUNT_ID&symbol=BTCUSDT" | jq
+```
+
+### Отмена ордера
+
+```bash
+curl -s -X DELETE "http://localhost:3000/v1/orders/$ORDER_ID" | jq
+```
+
+Все ответы сервиса сериализуют `bigint` в строки, поэтому значения полей `free`/`locked` либо `price`/`qty` всегда возвращаются строками. Такое представление можно напрямую сохранять или парсить в удобный формат (например, через `fromPriceInt`/`fromQtyInt` в SDK).

--- a/examples/03-accounts-and-orders/run.ts
+++ b/examples/03-accounts-and-orders/run.ts
@@ -1,0 +1,342 @@
+import process from 'node:process';
+import {
+  AccountsService,
+  ExchangeState,
+  OrdersService,
+  StaticMockOrderbook,
+  executeTimeline,
+  fromPriceInt,
+  fromQtyInt,
+  toPriceInt,
+  toQtyInt,
+  type MergedEvent,
+  type Order,
+  type PriceInt,
+  type QtyInt,
+  type SymbolId,
+} from '@tradeforge/core';
+import { buildDepthReader, buildTradesReader } from '../_shared/readers.js';
+import { buildMerged } from '../_shared/merge.js';
+import { runScenario } from '../_shared/replay.js';
+import { createLogger } from '../_shared/logging.js';
+import { createAccountWithDeposit } from '../_shared/accounts.js';
+
+type AsyncEventQueue<T> = {
+  iterable: AsyncIterable<T>;
+  push(value: T): void;
+  close(): void;
+};
+
+function createAsyncEventQueue<T>(): AsyncEventQueue<T> {
+  const values: T[] = [];
+  const waiting: Array<(value: IteratorResult<T>) => void> = [];
+  let closed = false;
+
+  const resolveNext = (result: IteratorResult<T>): void => {
+    const resolver = waiting.shift();
+    if (resolver) {
+      resolver(result);
+    }
+  };
+
+  const iterable: AsyncIterable<T> = {
+    [Symbol.asyncIterator](): AsyncIterator<T> {
+      return {
+        next(): Promise<IteratorResult<T>> {
+          if (values.length > 0) {
+            const value = values.shift()!;
+            return Promise.resolve({ value, done: false });
+          }
+          if (closed) {
+            return Promise.resolve({
+              value: undefined as unknown as T,
+              done: true,
+            });
+          }
+          return new Promise((resolve) => {
+            waiting.push(resolve);
+          });
+        },
+        return(): Promise<IteratorResult<T>> {
+          closed = true;
+          values.length = 0;
+          while (waiting.length > 0) {
+            resolveNext({ value: undefined as unknown as T, done: true });
+          }
+          return Promise.resolve({
+            value: undefined as unknown as T,
+            done: true,
+          });
+        },
+      } satisfies AsyncIterator<T>;
+    },
+  };
+
+  return {
+    iterable,
+    push(value: T) {
+      if (closed) return;
+      if (waiting.length > 0) {
+        resolveNext({ value, done: false });
+      } else {
+        values.push(value);
+      }
+    },
+    close() {
+      if (closed) return;
+      closed = true;
+      if (waiting.length > 0) {
+        while (waiting.length > 0) {
+          resolveNext({ value: undefined as unknown as T, done: true });
+        }
+      }
+    },
+  } satisfies AsyncEventQueue<T>;
+}
+
+const logger = createLogger({ prefix: '[examples/03-accounts-and-orders]' });
+
+const SYMBOL: SymbolId = 'BTCUSDT' as SymbolId;
+const SYMBOL_CONFIG = {
+  base: 'BTC',
+  quote: 'USDT',
+  priceScale: 5,
+  qtyScale: 6,
+};
+
+const FEE_CONFIG = {
+  makerBps: 5,
+  takerBps: 7,
+};
+
+function formatQty(value: QtyInt): string {
+  return fromQtyInt(value, SYMBOL_CONFIG.qtyScale);
+}
+
+function formatPrice(value: PriceInt): string {
+  return fromPriceInt(value, SYMBOL_CONFIG.priceScale);
+}
+
+function formatBalances(
+  balances: Record<string, { free: bigint; locked: bigint }>,
+): Record<string, { free: string; locked: string }> {
+  const formatted: Record<string, { free: string; locked: string }> = {};
+  for (const [currency, entry] of Object.entries(balances)) {
+    if (currency === SYMBOL_CONFIG.base) {
+      formatted[currency] = {
+        free: fromQtyInt(
+          entry.free as unknown as QtyInt,
+          SYMBOL_CONFIG.qtyScale,
+        ),
+        locked: fromQtyInt(
+          entry.locked as unknown as QtyInt,
+          SYMBOL_CONFIG.qtyScale,
+        ),
+      };
+    } else if (currency === SYMBOL_CONFIG.quote) {
+      formatted[currency] = {
+        free: fromPriceInt(
+          entry.free as unknown as PriceInt,
+          SYMBOL_CONFIG.priceScale,
+        ),
+        locked: fromPriceInt(
+          entry.locked as unknown as PriceInt,
+          SYMBOL_CONFIG.priceScale,
+        ),
+      };
+    } else {
+      formatted[currency] = {
+        free: entry.free.toString(),
+        locked: entry.locked.toString(),
+      };
+    }
+  }
+  return formatted;
+}
+
+function resolveInputFiles(kind: 'trades' | 'depth'): string[] {
+  const envKey = kind === 'trades' ? 'TF_TRADES_FILES' : 'TF_DEPTH_FILES';
+  const raw = process.env[envKey];
+  const list = (raw ?? '')
+    .split(/[\n,]/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  if (list.length > 0) {
+    return list;
+  }
+  const fallback =
+    kind === 'trades'
+      ? 'examples/_smoke/mini-trades.jsonl'
+      : 'examples/_smoke/mini-depth.jsonl';
+  return [fallback];
+}
+
+async function main(): Promise<void> {
+  logger.info('preparing merged timeline (trades + depth)');
+  const trades = buildTradesReader(resolveInputFiles('trades'));
+  const depth = buildDepthReader(resolveInputFiles('depth'));
+  const timeline = buildMerged(trades, depth);
+
+  const state = new ExchangeState({
+    symbols: { [SYMBOL as unknown as string]: SYMBOL_CONFIG },
+    fee: FEE_CONFIG,
+    orderbook: new StaticMockOrderbook({ best: {} }),
+  });
+  const accounts = new AccountsService(state);
+  const orders = new OrdersService(state, accounts);
+
+  const deposit = toPriceInt('1000', SYMBOL_CONFIG.priceScale);
+  const { account, accountId } = await createAccountWithDeposit(
+    {
+      accounts,
+      symbol: {
+        id: SYMBOL as unknown as string,
+        base: SYMBOL_CONFIG.base,
+        quote: SYMBOL_CONFIG.quote,
+      },
+    },
+    { quote: deposit.toString() },
+  );
+  const accountIdStr = accountId;
+  logger.info(
+    `created account ${accountIdStr} and deposited ${formatPrice(deposit)} ${SYMBOL_CONFIG.quote}`,
+  );
+
+  const buyQty = toQtyInt('0.030', SYMBOL_CONFIG.qtyScale);
+  const buyPrice = toPriceInt('27000.40', SYMBOL_CONFIG.priceScale);
+  const buyOrder = orders.placeOrder({
+    accountId: account.id,
+    symbol: SYMBOL,
+    type: 'LIMIT',
+    side: 'BUY',
+    qty: buyQty,
+    price: buyPrice,
+  });
+  logger.info(
+    `placed BUY order ${String(buyOrder.id)} -> qty=${formatQty(buyQty)}, price=${formatPrice(buyPrice)} ${SYMBOL_CONFIG.quote}`,
+  );
+
+  const targetSellQty = toQtyInt('0.015', SYMBOL_CONFIG.qtyScale);
+  const targetSellQtyRaw = targetSellQty as unknown as bigint;
+  const sellPrice = toPriceInt('27000.55', SYMBOL_CONFIG.priceScale);
+  const restingBuyPrice = toPriceInt('26999.50', SYMBOL_CONFIG.priceScale);
+  const restingBuyQty = toQtyInt('0.005', SYMBOL_CONFIG.qtyScale);
+
+  let sellOrder: Order | undefined;
+  let restingBuyOrder: Order | undefined;
+
+  const queue = createAsyncEventQueue<MergedEvent>();
+  const executionTask = (async () => {
+    for await (const report of executeTimeline(queue.iterable, state)) {
+      if (report.kind === 'FILL' && report.fill && report.orderId) {
+        const fillQtyStr = formatQty(report.fill.qty);
+        const fillPriceStr = formatPrice(report.fill.price);
+        logger.info(
+          `fill ${String(report.orderId)} side=${report.fill.side} qty=${fillQtyStr} price=${fillPriceStr}`,
+        );
+      }
+
+      if (report.kind === 'FILL' && report.orderId === buyOrder.id) {
+        const current = orders.getOrder(buyOrder.id);
+        const executedRaw = current.executedQty as unknown as bigint;
+        if (!sellOrder && executedRaw >= targetSellQtyRaw) {
+          sellOrder = orders.placeOrder({
+            accountId: account.id,
+            symbol: SYMBOL,
+            type: 'LIMIT',
+            side: 'SELL',
+            qty: targetSellQty,
+            price: sellPrice,
+          });
+          logger.info(
+            `placed SELL order ${String(sellOrder.id)} -> qty=${formatQty(targetSellQty)}, price=${formatPrice(sellPrice)}`,
+          );
+        }
+      }
+
+      if (
+        sellOrder &&
+        report.kind === 'FILL' &&
+        report.orderId === sellOrder.id &&
+        !restingBuyOrder
+      ) {
+        restingBuyOrder = orders.placeOrder({
+          accountId: account.id,
+          symbol: SYMBOL,
+          type: 'LIMIT',
+          side: 'BUY',
+          qty: restingBuyQty,
+          price: restingBuyPrice,
+        });
+        logger.info(
+          `placed resting BUY order ${String(restingBuyOrder.id)} -> qty=${formatQty(restingBuyQty)}, price=${formatPrice(restingBuyPrice)}`,
+        );
+      }
+    }
+  })();
+
+  let replayError: unknown;
+  try {
+    const progress = await runScenario({
+      timeline,
+      clock: 'logical',
+      limits: { maxEvents: 32 },
+      logger,
+      onEvent: (event) => {
+        queue.push(event);
+      },
+    });
+    logger.info(`replay finished after ${progress.eventsOut} events`);
+  } catch (err) {
+    replayError = err;
+  } finally {
+    queue.close();
+  }
+
+  try {
+    await executionTask;
+  } catch (err) {
+    if (!replayError) {
+      replayError = err;
+    }
+  }
+
+  if (replayError) {
+    throw replayError;
+  }
+
+  if (restingBuyOrder) {
+    logger.info(`canceling resting order ${String(restingBuyOrder.id)}`);
+    orders.cancelOrder(restingBuyOrder.id);
+  }
+
+  const openOrders = orders.listOpenOrders(account.id, SYMBOL);
+  if (openOrders.length > 0) {
+    for (const order of openOrders) {
+      if (!restingBuyOrder || order.id !== restingBuyOrder.id) {
+        logger.info(`canceling leftover order ${String(order.id)}`);
+      }
+      orders.cancelOrder(order.id);
+    }
+  }
+
+  const balances = accounts.getBalancesSnapshot(account.id);
+  const formattedBalances = formatBalances(balances);
+  logger.info(
+    `final balances for ${accountIdStr}: ${JSON.stringify(formattedBalances)}`,
+  );
+  const finalOpenOrders = orders.listOpenOrders(account.id, SYMBOL).length;
+  console.log('ACC_ORDERS_OK', {
+    balances: formattedBalances,
+    openOrdersCount: finalOpenOrders,
+  });
+}
+
+main().catch((err) => {
+  const message = err instanceof Error ? err.message : String(err);
+  logger.error(`scenario failed: ${message}`);
+  if (err instanceof Error && err.stack) {
+    logger.debug(err.stack);
+  }
+  process.exit(1);
+});

--- a/examples/03-accounts-and-orders/smoke.ts
+++ b/examples/03-accounts-and-orders/smoke.ts
@@ -1,0 +1,57 @@
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import process from 'node:process';
+
+function ensureMarker(output: string): void {
+  if (!output.includes('ACC_ORDERS_OK')) {
+    throw new Error('marker ACC_ORDERS_OK not found in stdout');
+  }
+}
+
+function main(): void {
+  const trades = resolve('examples', '_smoke', 'mini-trades.jsonl');
+  const depth = resolve('examples', '_smoke', 'mini-depth.jsonl');
+
+  const result = spawnSync(
+    'node',
+    ['dist-examples/03-accounts-and-orders/run.js'],
+    {
+      env: {
+        ...process.env,
+        TF_TRADES_FILES: process.env['TF_TRADES_FILES'] ?? trades,
+        TF_DEPTH_FILES: process.env['TF_DEPTH_FILES'] ?? depth,
+      },
+      encoding: 'utf8',
+      stdio: 'pipe',
+    },
+  );
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (typeof result.status === 'number' && result.status !== 0) {
+    const stderr = result.stderr ? `\n${result.stderr}` : '';
+    throw new Error(`example exited with code ${result.status}${stderr}`);
+  }
+
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+
+  ensureMarker(result.stdout ?? '');
+  console.log('EX03_ACC_ORDERS_SMOKE_OK');
+}
+
+try {
+  main();
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error('[examples/03-accounts-and-orders] smoke failed:', message);
+  if (err instanceof Error && err.stack) {
+    console.error(err.stack);
+  }
+  process.exit(1);
+}

--- a/examples/_shared/bin/find-files.ts
+++ b/examples/_shared/bin/find-files.ts
@@ -75,7 +75,7 @@ function matchesKind(file: string, kind?: 'trades' | 'depth'): boolean {
 async function run(): Promise<void> {
   try {
     const { patterns, options } = parseArgs(process.argv.slice(2));
-    const files = await fg(patterns, {
+    const files = await fg<string>(patterns, {
       cwd: options.cwd,
       dot: false,
       onlyFiles: true,

--- a/examples/types/fast-glob.d.ts
+++ b/examples/types/fast-glob.d.ts
@@ -1,0 +1,15 @@
+declare module 'fast-glob' {
+  type FastGlobOptions = {
+    cwd?: string;
+    dot?: boolean;
+    onlyFiles?: boolean;
+    absolute?: boolean;
+  };
+
+  function fastGlob<T extends string | Buffer = string>(
+    patterns: string | readonly string[],
+    options?: FastGlobOptions,
+  ): Promise<T[]>;
+
+  export default fastGlob;
+}


### PR DESCRIPTION
## Summary
- fill the example README with step-by-step CLI, SDK and REST walkthroughs for working with accounts and LIMIT orders
- implement `run.ts` to create an account, place/cancel orders and print the `ACC_ORDERS_OK` marker with balances
- add a smoke script and minimal typings so the example can be built and verified with the shared tooling

## Testing
- `pnpm -w examples:build`
- `TF_TRADES_FILES=examples/_smoke/mini-trades.jsonl TF_DEPTH_FILES=examples/_smoke/mini-depth.jsonl node dist-examples/03-accounts-and-orders/run.js`
- `node examples/03-accounts-and-orders/smoke.ts`

## Checklist
- [x] README заполнен (CLI/SDK/REST)
- [x] run.ts реализован
- [x] smoke.ts добавлен
- [ ] CI зелёный

------
https://chatgpt.com/codex/tasks/task_e_68cb011564cc8320a1279cb7c6cd2980