### PR TITLE
docs(examples): 05-pause-auto-checkpoint (CLI + SDK)

### DIFF
--- a/examples/05-pause-auto-checkpoint/README.md
+++ b/examples/05-pause-auto-checkpoint/README.md
@@ -1,9 +1,76 @@
-# 05. Pause & Auto Checkpoint
+# 05 — Пауза старта и автосейв чекпоинтов
 
-TODO: показать работу паузы и автосохранения чекпоинтов.
+Пример демонстрирует управление симуляцией: стартуем прогон на паузе, вручную продолжаем выполнение и наблюдаем автоматическое сохранение чекпоинтов по событиям и по таймеру. Скрипт и CLI используют мини-фикстуры из `examples/_smoke`, логические часы и периодически сохраняют `checkpoint.v1`.
 
-## Черновик плана
+## Требования
 
-- [ ] Передать `pauseOnStart` и управлять контроллером вручную.
-- [ ] Настроить `autoCp` с путём `TF_CP_PATH`.
-- [ ] Продемонстрировать перезапуск сценария с чекпоинта.
+- Установленные зависимости (`pnpm install`).
+- Сборка рабочих пакетов (`pnpm -w build`).
+- Наличие исторических данных по сделкам и стакану (для быстрого старта подойдут файлы из [`examples/_smoke`](../_smoke/)).
+
+## Вариант A — CLI
+
+1. Указываем данные через переменные окружения (можно перечислять несколько путём разделения запятыми или переносами строки):
+
+   ```bash
+   export TF_TRADES_FILES="examples/_smoke/mini-trades.jsonl"
+   export TF_DEPTH_FILES="examples/_smoke/mini-depth.jsonl"
+   ```
+
+2. Запускаем симуляцию с паузой старта и автосохранением чекпоинтов:
+
+   ```bash
+   pnpm --filter @tradeforge/cli dev -- simulate \
+     --trades "$TF_TRADES_FILES" \
+     --depth "$TF_DEPTH_FILES" \
+     --clock logical \
+     --max-events 120 \
+     --pause-on-start \
+     --checkpoint-save /tmp/tf.cp.json \
+     --cp-interval-events 20 \
+     --cp-interval-wall-ms 500 \
+     --summary
+   ```
+
+   Что произойдёт:
+   - CLI стартует сценарий, сразу поставит контроллер на паузу и покажет приглашение `Press Enter to resume…`.
+   - После нажатия Enter симуляция продолжится, а каждые 20 событий либо каждые 500 мс будет записываться `checkpoint.v1` по указанному пути (`/tmp/tf.cp.json`).
+   - В логах появятся сообщения `checkpoint saved -> …` и сжатый summary по окончании выполнения.
+
+   Параметры можно адаптировать: например, поменять путь сохранения (`--checkpoint-save`), увеличить частоту автосейвов (`--cp-interval-events`, `--cp-interval-wall-ms`) или задать другой лимит событий (`--max-events`).
+
+## Вариант B — SDK (TypeScript)
+
+1. Собираем папку `dist-examples/**`:
+
+   ```bash
+   pnpm -w examples:build
+   ```
+
+2. Запускаем скрипт `run.ts`, который автоматически ставит симуляцию на паузу, затем возобновляет и сохраняет чекпоинты:
+
+   ```bash
+   TF_TRADES_FILES="examples/_smoke/mini-trades.jsonl" \
+   TF_DEPTH_FILES="examples/_smoke/mini-depth.jsonl" \
+   TF_CP_PATH=/tmp/tf.cp.json \
+   TF_MAX_EVENTS=100 \
+   TF_CP_INTERVAL_EVENTS=20 \
+   TF_CP_INTERVAL_WALL_MS=500 \
+   node dist-examples/05-pause-auto-checkpoint/run.js
+   ```
+
+   Дополнительные переменные окружения:
+   - `TF_RESUME_DELAY_MS` — задержка перед автоматическим `resume()` (по умолчанию 600 мс).
+   - `TF_TIE_BREAK` — выбор источника при совпадении меток (`DEPTH` или `TRADES`).
+
+   После завершения в stdout появится строка `PAUSE_CP_OK { cpExists: true, … }`. Это подтверждает, что файл чекпоинта создан, а скрипт успешно снял паузу и прошёл лимит событий.
+
+## Smoke-проверка
+
+Для быстрой проверки сценария предусмотрен мини-тест:
+
+```bash
+node examples/05-pause-auto-checkpoint/smoke.ts
+```
+
+Скрипт выполнит собранный пример, убедится в наличии чекпоинта и проверит маркер `PAUSE_CP_OK` в stdout.

--- a/examples/05-pause-auto-checkpoint/run.ts
+++ b/examples/05-pause-auto-checkpoint/run.ts
@@ -1,0 +1,216 @@
+import { existsSync, rmSync } from 'node:fs';
+import { resolve } from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+import {
+  createReplayController,
+  ExchangeState,
+  StaticMockOrderbook,
+  type CoreReaderCursor,
+  type ReplayProgress,
+} from '@tradeforge/core';
+import { buildDepthReader, buildTradesReader } from '../_shared/readers.js';
+import { buildMerged } from '../_shared/merge.js';
+import { runScenario } from '../_shared/replay.js';
+import { createLogger, formatProgress } from '../_shared/logging.js';
+import { makeCp } from '../_shared/checkpoint.js';
+
+const logger = createLogger({ prefix: '[examples/05-pause-auto-checkpoint]' });
+
+const DEFAULT_TRADES = resolve('examples', '_smoke', 'mini-trades.jsonl');
+const DEFAULT_DEPTH = resolve('examples', '_smoke', 'mini-depth.jsonl');
+const DEFAULT_CP_PATH = '/tmp/tf.cp.json';
+
+function resolveCheckpointPath(): string {
+  const raw = process.env['TF_CP_PATH'];
+  if (raw && raw.trim()) {
+    return raw.trim();
+  }
+  return DEFAULT_CP_PATH;
+}
+
+function parsePositiveInt(raw: string | undefined, fallback: number): number {
+  if (!raw) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
+function parseNonNegativeInt(
+  raw: string | undefined,
+  fallback: number,
+): number {
+  if (!raw) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
+function preferredFiles(
+  envKey: 'TF_TRADES_FILES' | 'TF_DEPTH_FILES',
+  fallback: string,
+): string[] {
+  const envValue = process.env[envKey];
+  if (envValue && envValue.trim()) {
+    return [];
+  }
+  return [fallback];
+}
+
+function resolveTieBreak(): 'DEPTH' | 'TRADES' {
+  const raw = process.env['TF_TIE_BREAK']?.trim().toUpperCase();
+  if (raw === 'TRADES') {
+    return 'TRADES';
+  }
+  return 'DEPTH';
+}
+
+function currentCursorOf(source: unknown): CoreReaderCursor | undefined {
+  if (!source || typeof source !== 'object') {
+    return undefined;
+  }
+  const maybe = source as { currentCursor?: () => CoreReaderCursor };
+  if (typeof maybe.currentCursor !== 'function') {
+    return undefined;
+  }
+  try {
+    return maybe.currentCursor();
+  } catch {
+    return undefined;
+  }
+}
+
+export async function run(): Promise<{
+  progress: ReplayProgress;
+  checkpointPath: string;
+}> {
+  const tradesReader = buildTradesReader(
+    preferredFiles('TF_TRADES_FILES', DEFAULT_TRADES),
+  );
+  const depthReader = buildDepthReader(
+    preferredFiles('TF_DEPTH_FILES', DEFAULT_DEPTH),
+  );
+  const timeline = buildMerged(tradesReader, depthReader);
+
+  const controller = createReplayController();
+  const checkpointPath = resolveCheckpointPath();
+  if (existsSync(checkpointPath)) {
+    rmSync(checkpointPath, { force: true });
+    logger.debug(`removed existing checkpoint at ${checkpointPath}`);
+  }
+
+  const symbol = (process.env['TF_SYMBOL'] ?? 'BTCUSDT').toUpperCase();
+  const state = new ExchangeState({
+    symbols: {
+      [symbol]: {
+        base: 'BTC',
+        quote: 'USDT',
+        priceScale: 2,
+        qtyScale: 4,
+      },
+    },
+    fee: { makerBps: 10, takerBps: 20 },
+    orderbook: new StaticMockOrderbook({ best: {} }),
+  });
+
+  const mergeState = { nextSourceOnEqualTs: resolveTieBreak() };
+  const cpIntervalEvents = parsePositiveInt(
+    process.env['TF_CP_INTERVAL_EVENTS'],
+    20,
+  );
+  const cpIntervalWallMs = parsePositiveInt(
+    process.env['TF_CP_INTERVAL_WALL_MS'],
+    500,
+  );
+  const maxEvents = parsePositiveInt(process.env['TF_MAX_EVENTS'], 100);
+  const resumeDelayMs = parseNonNegativeInt(
+    process.env['TF_RESUME_DELAY_MS'],
+    600,
+  );
+
+  logger.info(
+    `preparing replay (maxEvents=${maxEvents}) checkpointPath=${checkpointPath}`,
+  );
+  logger.info(
+    `auto-checkpoint every ${cpIntervalEvents} events or ${cpIntervalWallMs}ms`,
+  );
+
+  setTimeout(() => {
+    logger.info(`resuming replay after pause (${resumeDelayMs}ms)`);
+    controller.resume();
+  }, resumeDelayMs);
+
+  const progress = await runScenario({
+    timeline,
+    clock: 'logical',
+    limits: { maxEvents },
+    controller,
+    pauseOnStart: true,
+    autoCp: {
+      savePath: checkpointPath,
+      cpIntervalEvents,
+      cpIntervalWallMs,
+      buildCheckpoint: async () => {
+        const cursors: { trades?: CoreReaderCursor; depth?: CoreReaderCursor } =
+          {};
+        const tradesCursor = currentCursorOf(tradesReader);
+        if (tradesCursor) {
+          cursors.trades = tradesCursor;
+        }
+        const depthCursor = currentCursorOf(depthReader);
+        if (depthCursor) {
+          cursors.depth = depthCursor;
+        }
+        return makeCp({
+          symbol,
+          state,
+          merge: mergeState,
+          cursors,
+          note: 'auto-checkpoint (examples/05)',
+        });
+      },
+    },
+    logger,
+  });
+
+  logger.info(`replay complete ${formatProgress(progress)}`);
+  return { progress, checkpointPath };
+}
+
+async function main(): Promise<void> {
+  try {
+    const { progress, checkpointPath } = await run();
+    const cpExists = existsSync(checkpointPath);
+    const wallElapsed = Math.max(0, progress.wallLastMs - progress.wallStartMs);
+    const marker = {
+      eventsOut: progress.eventsOut,
+      wallMs: wallElapsed,
+      cpExists,
+    };
+    console.log('PAUSE_CP_OK', marker);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error(message);
+    if (err instanceof Error && err.stack) {
+      logger.debug(err.stack);
+    }
+    console.error('PAUSE_CP_FAILED', message);
+    process.exit(1);
+  }
+}
+
+const invokedFromCli =
+  process.argv[1] &&
+  pathToFileURL(resolve(process.argv[1]!)).href === import.meta.url;
+
+if (invokedFromCli) {
+  void main();
+}

--- a/examples/05-pause-auto-checkpoint/smoke.ts
+++ b/examples/05-pause-auto-checkpoint/smoke.ts
@@ -1,0 +1,79 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, rmSync } from 'node:fs';
+import { resolve } from 'node:path';
+import process from 'node:process';
+
+function ensureMarker(output: string): void {
+  if (!output.includes('PAUSE_CP_OK')) {
+    throw new Error('marker PAUSE_CP_OK not found in stdout');
+  }
+}
+
+function removeIfExists(path: string): void {
+  if (!path) {
+    return;
+  }
+  if (existsSync(path)) {
+    rmSync(path, { force: true });
+  }
+}
+
+function main(): void {
+  const trades = resolve('examples', '_smoke', 'mini-trades.jsonl');
+  const depth = resolve('examples', '_smoke', 'mini-depth.jsonl');
+  const cpPath = process.env['TF_CP_PATH']?.trim() || '/tmp/tf.cp.json';
+
+  removeIfExists(cpPath);
+
+  const result = spawnSync(
+    'node',
+    ['dist-examples/05-pause-auto-checkpoint/run.js'],
+    {
+      env: {
+        ...process.env,
+        TF_TRADES_FILES: process.env['TF_TRADES_FILES'] ?? trades,
+        TF_DEPTH_FILES: process.env['TF_DEPTH_FILES'] ?? depth,
+        TF_CP_PATH: cpPath,
+        TF_MAX_EVENTS: process.env['TF_MAX_EVENTS'] ?? '80',
+        TF_CP_INTERVAL_EVENTS: process.env['TF_CP_INTERVAL_EVENTS'] ?? '20',
+        TF_CP_INTERVAL_WALL_MS: process.env['TF_CP_INTERVAL_WALL_MS'] ?? '500',
+        TF_RESUME_DELAY_MS: process.env['TF_RESUME_DELAY_MS'] ?? '600',
+      },
+      encoding: 'utf8',
+      stdio: 'pipe',
+    },
+  );
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (typeof result.status === 'number' && result.status !== 0) {
+    const stderr = result.stderr ? `\n${result.stderr}` : '';
+    throw new Error(`example exited with code ${result.status}${stderr}`);
+  }
+
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+
+  ensureMarker(result.stdout ?? '');
+  if (!existsSync(cpPath)) {
+    throw new Error(`checkpoint not found at ${cpPath}`);
+  }
+
+  console.log('PAUSE_CP_SMOKE_OK');
+}
+
+try {
+  main();
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error('[examples/05-pause-auto-checkpoint] smoke failed:', message);
+  if (err instanceof Error && err.stack) {
+    console.error(err.stack);
+  }
+  process.exit(1);
+}

--- a/examples/_shared/bin/find-files.ts
+++ b/examples/_shared/bin/find-files.ts
@@ -75,13 +75,15 @@ function matchesKind(file: string, kind?: 'trades' | 'depth'): boolean {
 async function run(): Promise<void> {
   try {
     const { patterns, options } = parseArgs(process.argv.slice(2));
-    const files = await fg(patterns, {
+    const files = (await fg(patterns, {
       cwd: options.cwd,
       dot: false,
       onlyFiles: true,
       absolute: true,
-    });
-    const filtered = files.filter((file) => matchesKind(file, options.kind));
+    })) as string[];
+    const filtered = files.filter((file: string) =>
+      matchesKind(file, options.kind),
+    );
     const sorted = [...new Set(filtered)].sort();
     for (const file of sorted) {
       const output = options.relative

--- a/examples/types/fast-glob.d.ts
+++ b/examples/types/fast-glob.d.ts
@@ -1,0 +1,18 @@
+declare module 'fast-glob' {
+  export interface FastGlobOptions {
+    cwd?: string;
+    dot?: boolean;
+    onlyFiles?: boolean;
+    absolute?: boolean;
+  }
+
+  export default function fg(
+    patterns: string | readonly string[],
+    options?: FastGlobOptions,
+  ): Promise<string[]>;
+
+  export function sync(
+    patterns: string | readonly string[],
+    options?: FastGlobOptions,
+  ): string[];
+}


### PR DESCRIPTION
## Summary
- document CLI workflow for pausing a simulation and enabling automatic checkpoint saves
- add SDK script that starts paused, resumes after a delay, and writes auto checkpoints to /tmp/tf.cp.json
- provide a smoke script plus minimal fast-glob typings so the example build succeeds

## Testing
- `pnpm -w examples:build`
- `node dist-examples/05-pause-auto-checkpoint/run.js`
- `node examples/05-pause-auto-checkpoint/smoke.ts`

## Checklist
- [x] README с CLI-флагами
- [x] run.ts реализован
- [x] smoke.ts добавлен
- [ ] CI зелёный

------
https://chatgpt.com/codex/tasks/task_e_68cb011d01dc832098a17de93f07fe4a