### PR TITLE
docs(examples): 07-summary-and-ndjson (CLI + SDK)

### DIFF
--- a/examples/07-summary-and-ndjson/README.md
+++ b/examples/07-summary-and-ndjson/README.md
@@ -1,9 +1,92 @@
-# 07. Summary & NDJSON
+# 07 — Сводка и экспорт NDJSON
 
-TODO: показать выгрузку итогов и потоковых данных в NDJSON.
+Пример показывает два способа собрать агрегированную статистику по прогону:
+через CLI (`--summary`) и через SDK-скрипт, который одновременно пишет поток
+`ExecutionReport` в NDJSON для последующей аналитики.
 
-## Черновик плана
+Мини-фикстуры (десятки событий) лежат в [`examples/_smoke`](../_smoke/).
 
-- [ ] Сформировать summary по результатам `runScenario`.
-- [ ] Добавить пример записи событий в файл (NDJSON).
-- [ ] Документировать формат вывода.
+## Требования
+
+- Установленные зависимости (`pnpm install`).
+- Сборка пакетов (`pnpm -w build`).
+- Сборка примеров перед запуском SDK (`pnpm -w examples:build`).
+
+## Вариант A — CLI: summary и NDJSON
+
+1. Подготовьте переменные окружения с путями к мини-фикстурам:
+
+   ```bash
+   export TF_TRADES_FILES="examples/_smoke/mini-trades.jsonl"
+   export TF_DEPTH_FILES="examples/_smoke/mini-depth.jsonl"
+   ```
+
+2. Запустите симуляцию с флагом `--summary`. CLI распечатает два JSON-объекта:
+   метаданные прогона и агрегированную сводку (итоги по ордерам, балансам и
+   комиссиям). Все `bigint` сериализуются в строки.
+
+   ```bash
+   pnpm --filter @tradeforge/cli dev -- simulate \
+     --trades "$TF_TRADES_FILES" \
+     --depth "$TF_DEPTH_FILES" \
+     --clock logical \
+     --max-events 32 \
+     --summary
+   ```
+
+3. Для потоковой выгрузки отчётов воспользуйтесь флагом `--ndjson` и
+   перенаправьте stdout в файл. Агрегированная сводка по ордерам продолжит
+   печататься после завершения прогона.
+
+   ```bash
+   pnpm --filter @tradeforge/cli dev -- simulate \
+     --trades "$TF_TRADES_FILES" \
+     --depth "$TF_DEPTH_FILES" \
+     --clock logical \
+     --max-events 32 \
+     --ndjson > /tmp/tf.reports.ndjson
+   ```
+
+### Post-processing NDJSON
+
+После завершения CLI можно быстро проверить структуру потока.
+
+- Подсчёт типов отчётов (`eventType`) через `jq`:
+
+  ```bash
+  jq -r '.["eventType"]' /tmp/tf.reports.ndjson | sort | uniq -c
+  ```
+
+- Подсчёт числа сделок (fill) через `awk`:
+
+  ```bash
+  awk -F'"' '/"eventType":"FILL"/ { fills += 1 } END { print "fills=" fills }' \
+    /tmp/tf.reports.ndjson
+  ```
+
+## Вариант B — SDK (TypeScript)
+
+1. Соберите примеры, чтобы получить `dist-examples/**`:
+
+   ```bash
+   pnpm -w examples:build
+   ```
+
+2. Запустите скрипт. Он формирует merged timeline на мини-фикстурах, запускает
+   симуляцию с логическими часами и пишет поток `ExecutionReport` в
+   `/tmp/tf.reports.ndjson` по мере поступления событий. После завершения
+   скрипт печатает агрегированную сводку и строку `SUMMARY_NDJSON_OK` с числом
+   записей и длительностью прогона.
+
+   ```bash
+   node dist-examples/07-summary-and-ndjson/run.js
+   ```
+
+3. Для проверки NDJSON можно воспользоваться smoke-скриптом:
+
+   ```bash
+   node examples/07-summary-and-ndjson/smoke.ts
+   ```
+
+   Он запускает собранный SDK-пример, убеждается в наличии `/tmp/tf.reports.ndjson`
+   и проверяет, что в файле есть хотя бы одна строка.

--- a/examples/07-summary-and-ndjson/run.ts
+++ b/examples/07-summary-and-ndjson/run.ts
@@ -1,0 +1,393 @@
+import { once } from 'node:events';
+import { createWriteStream, existsSync } from 'node:fs';
+import { readFile, rm } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { finished } from 'node:stream/promises';
+import {
+  AccountsService,
+  ExchangeState,
+  OrdersService,
+  StaticMockOrderbook,
+  executeTimeline,
+  fromPriceInt,
+  fromQtyInt,
+  toPriceInt,
+  toQtyInt,
+  type MergedEvent,
+  type ReplayProgress,
+  type PriceInt,
+  type QtyInt,
+  type SymbolId,
+} from '@tradeforge/core';
+import { createAccountWithDeposit } from '../_shared/accounts.js';
+import { createLogger } from '../_shared/logging.js';
+import { buildMerged } from '../_shared/merge.js';
+import { runScenario } from '../_shared/replay.js';
+import { buildDepthReader, buildTradesReader } from '../_shared/readers.js';
+
+type AsyncEventQueue<T> = {
+  iterable: AsyncIterable<T>;
+  push(value: T): void;
+  close(): void;
+};
+
+function createAsyncEventQueue<T>(): AsyncEventQueue<T> {
+  const values: T[] = [];
+  const waiting: Array<(value: IteratorResult<T>) => void> = [];
+  let closed = false;
+
+  const resolveNext = (result: IteratorResult<T>): void => {
+    const resolver = waiting.shift();
+    if (resolver) {
+      resolver(result);
+    }
+  };
+
+  const iterable: AsyncIterable<T> = {
+    [Symbol.asyncIterator](): AsyncIterator<T> {
+      return {
+        next(): Promise<IteratorResult<T>> {
+          if (values.length > 0) {
+            const value = values.shift()!;
+            return Promise.resolve({ value, done: false });
+          }
+          if (closed) {
+            return Promise.resolve({
+              value: undefined as unknown as T,
+              done: true,
+            });
+          }
+          return new Promise((resolve) => {
+            waiting.push(resolve);
+          });
+        },
+        return(): Promise<IteratorResult<T>> {
+          closed = true;
+          values.length = 0;
+          while (waiting.length > 0) {
+            resolveNext({ value: undefined as unknown as T, done: true });
+          }
+          return Promise.resolve({
+            value: undefined as unknown as T,
+            done: true,
+          });
+        },
+      } satisfies AsyncIterator<T>;
+    },
+  };
+
+  return {
+    iterable,
+    push(value: T) {
+      if (closed) return;
+      if (waiting.length > 0) {
+        resolveNext({ value, done: false });
+      } else {
+        values.push(value);
+      }
+    },
+    close() {
+      if (closed) return;
+      closed = true;
+      if (waiting.length > 0) {
+        while (waiting.length > 0) {
+          resolveNext({ value: undefined as unknown as T, done: true });
+        }
+      }
+    },
+  } satisfies AsyncEventQueue<T>;
+}
+
+function jsonReplacer(_key: string, value: unknown): unknown {
+  if (typeof value === 'bigint') {
+    return value.toString(10);
+  }
+  return value;
+}
+
+type SummaryTotals = {
+  orders: {
+    total: number;
+    filled: number;
+    partiallyFilled: number;
+    canceled: number;
+  };
+  fills: number;
+  executedQty: bigint;
+  notional: bigint;
+  fees: { maker: bigint; taker: bigint };
+};
+
+function buildSummary(
+  state: ExchangeState,
+  accounts: AccountsService,
+): {
+  totals: SummaryTotals;
+  orders: Array<{
+    id: string;
+    side: string;
+    status: string;
+    qty: bigint;
+    executedQty: bigint;
+    cumulativeQuote: bigint;
+    fees: { maker?: bigint; taker?: bigint };
+    fills: number;
+  }>;
+  balances: Record<string, Record<string, { free: bigint; locked: bigint }>>;
+} {
+  const ordersList = Array.from(state.orders.values());
+  const totals: SummaryTotals = {
+    orders: {
+      total: ordersList.length,
+      filled: 0,
+      partiallyFilled: 0,
+      canceled: 0,
+    },
+    fills: 0,
+    executedQty: 0n,
+    notional: 0n,
+    fees: { maker: 0n, taker: 0n },
+  };
+
+  const ordersSummary = ordersList.map((order) => {
+    if (order.status === 'FILLED') totals.orders.filled += 1;
+    if (order.status === 'PARTIALLY_FILLED') totals.orders.partiallyFilled += 1;
+    if (order.status === 'CANCELED') totals.orders.canceled += 1;
+
+    const executedQty = order.executedQty as unknown as bigint;
+    const cumulativeQuote = order.cumulativeQuote as unknown as bigint;
+    const qty = order.qty as unknown as bigint;
+    const makerFee = order.fees.maker as unknown as bigint | undefined;
+    const takerFee = order.fees.taker as unknown as bigint | undefined;
+
+    totals.fills += order.fills.length;
+    totals.executedQty += executedQty;
+    totals.notional += cumulativeQuote;
+    if (makerFee !== undefined) {
+      totals.fees.maker += makerFee;
+    }
+    if (takerFee !== undefined) {
+      totals.fees.taker += takerFee;
+    }
+
+    return {
+      id: String(order.id),
+      side: order.side,
+      status: order.status,
+      qty,
+      executedQty,
+      cumulativeQuote,
+      fees: {
+        ...(makerFee !== undefined ? { maker: makerFee } : {}),
+        ...(takerFee !== undefined ? { taker: takerFee } : {}),
+      },
+      fills: order.fills.length,
+    };
+  });
+
+  const balances: Record<
+    string,
+    Record<string, { free: bigint; locked: bigint }>
+  > = {};
+  for (const [accountId] of state.accounts.entries()) {
+    balances[accountId as unknown as string] =
+      accounts.getBalancesSnapshot(accountId);
+  }
+
+  return { totals, orders: ordersSummary, balances };
+}
+
+const logger = createLogger({ prefix: '[examples/07-summary-and-ndjson]' });
+
+const OUTPUT_FILE = '/tmp/tf.reports.ndjson';
+const SYMBOL: SymbolId = 'BTCUSDT' as SymbolId;
+const SYMBOL_CONFIG = {
+  base: 'BTC',
+  quote: 'USDT',
+  priceScale: 5,
+  qtyScale: 6,
+};
+const FEE_CONFIG = {
+  makerBps: 5,
+  takerBps: 7,
+};
+
+function formatPrice(value: PriceInt): string {
+  return fromPriceInt(value, SYMBOL_CONFIG.priceScale);
+}
+
+function formatQty(value: QtyInt): string {
+  return fromQtyInt(value, SYMBOL_CONFIG.qtyScale);
+}
+
+async function main(): Promise<void> {
+  const here = dirname(fileURLToPath(import.meta.url));
+
+  function resolveFixture(file: string): string {
+    const local = resolve(here, '../_smoke', file);
+    if (existsSync(local)) {
+      return local;
+    }
+    return resolve(here, '../../examples/_smoke', file);
+  }
+
+  const tradesPath = resolveFixture('mini-trades.jsonl');
+  const depthPath = resolveFixture('mini-depth.jsonl');
+
+  logger.info('building merged timeline from mini fixtures');
+  const trades = buildTradesReader([tradesPath]);
+  const depth = buildDepthReader([depthPath]);
+  const timeline = buildMerged(trades, depth);
+
+  logger.info('initializing exchange state and services');
+  const state = new ExchangeState({
+    symbols: { [SYMBOL as unknown as string]: SYMBOL_CONFIG },
+    fee: FEE_CONFIG,
+    orderbook: new StaticMockOrderbook({ best: {} }),
+  });
+  const accounts = new AccountsService(state);
+  const orders = new OrdersService(state, accounts);
+
+  const deposit = toPriceInt('1000', SYMBOL_CONFIG.priceScale);
+  const { account, accountId } = await createAccountWithDeposit(
+    {
+      accounts,
+      symbol: {
+        id: SYMBOL as unknown as string,
+        base: SYMBOL_CONFIG.base,
+        quote: SYMBOL_CONFIG.quote,
+      },
+    },
+    { quote: deposit.toString() },
+  );
+  logger.info(
+    `created account ${accountId} with quote balance ${formatPrice(
+      deposit,
+    )} ${SYMBOL_CONFIG.quote}`,
+  );
+
+  const orderQty = toQtyInt('0.030', SYMBOL_CONFIG.qtyScale);
+  const orderPrice = toPriceInt('27000.60', SYMBOL_CONFIG.priceScale);
+  const buyOrder = orders.placeOrder({
+    accountId: account.id,
+    symbol: SYMBOL,
+    type: 'LIMIT',
+    side: 'BUY',
+    qty: orderQty,
+    price: orderPrice,
+  });
+  logger.info(
+    `placed LIMIT BUY ${String(buyOrder.id)} qty=${formatQty(
+      orderQty,
+    )} price=${formatPrice(orderPrice)} ${SYMBOL_CONFIG.quote}`,
+  );
+
+  await rm(OUTPUT_FILE, { force: true });
+  const ndjsonStream = createWriteStream(OUTPUT_FILE, { encoding: 'utf8' });
+  const queue = createAsyncEventQueue<MergedEvent>();
+  let rowsWritten = 0;
+
+  const executionPromise = (async () => {
+    try {
+      for await (const report of executeTimeline(queue.iterable, state)) {
+        const enriched = {
+          eventType: report.kind,
+          ...report,
+        };
+        const line = `${JSON.stringify(enriched, jsonReplacer)}\n`;
+        if (!ndjsonStream.write(line)) {
+          await once(ndjsonStream, 'drain');
+        }
+        rowsWritten += 1;
+      }
+    } finally {
+      ndjsonStream.end();
+    }
+    await finished(ndjsonStream);
+    return rowsWritten;
+  })();
+
+  let progress: ReplayProgress | undefined;
+  let replayError: unknown;
+  try {
+    progress = await runScenario({
+      timeline,
+      clock: 'logical',
+      limits: { maxEvents: 24 },
+      logger,
+      onEvent: (event) => {
+        queue.push(event);
+      },
+    });
+    logger.info(`replay finished after ${progress.eventsOut} events`);
+  } catch (err) {
+    replayError = err;
+  } finally {
+    queue.close();
+  }
+
+  let ndjsonRows = 0;
+  try {
+    ndjsonRows = await executionPromise;
+  } catch (err) {
+    if (!replayError) {
+      replayError = err;
+    }
+  }
+
+  if (replayError) {
+    throw replayError;
+  }
+  if (!progress) {
+    throw new Error('replay completed without progress stats');
+  }
+
+  logger.info(`execution reports saved to ${OUTPUT_FILE} (${ndjsonRows} rows)`);
+
+  const summary = {
+    ...buildSummary(state, accounts),
+    config: {
+      symbol: SYMBOL as unknown as string,
+      priceScale: SYMBOL_CONFIG.priceScale,
+      qtyScale: SYMBOL_CONFIG.qtyScale,
+    },
+  };
+  const summaryPrintable = JSON.parse(
+    JSON.stringify(summary, jsonReplacer),
+  ) as Record<string, unknown>;
+  console.log('SUMMARY_AGGREGATED');
+  console.log(JSON.stringify(summaryPrintable, null, 2));
+
+  const fileContent = await readFile(OUTPUT_FILE, 'utf8');
+  const rows = fileContent
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0).length;
+  if (rows <= 0) {
+    throw new Error('NDJSON output is empty');
+  }
+
+  const wallMs = Math.max(0, progress.wallLastMs - progress.wallStartMs);
+  const simMs =
+    progress.simStartTs !== undefined && progress.simLastTs !== undefined
+      ? Math.max(0, Number(progress.simLastTs) - Number(progress.simStartTs))
+      : 0;
+
+  console.log('SUMMARY_NDJSON_OK', {
+    rows,
+    eventsOut: progress.eventsOut,
+    wallMs,
+    simMs,
+  });
+}
+
+main().catch((err) => {
+  const message = err instanceof Error ? err.message : String(err);
+  logger.error(`example failed: ${message}`);
+  if (err instanceof Error && err.stack) {
+    logger.debug(err.stack);
+  }
+  process.exit(1);
+});

--- a/examples/07-summary-and-ndjson/smoke.ts
+++ b/examples/07-summary-and-ndjson/smoke.ts
@@ -1,0 +1,59 @@
+import { spawnSync } from 'node:child_process';
+import { constants } from 'node:fs';
+import { access, readFile } from 'node:fs/promises';
+import process from 'node:process';
+
+const OUTPUT_FILE = '/tmp/tf.reports.ndjson';
+
+async function ensureNdjson(): Promise<number> {
+  await access(OUTPUT_FILE, constants.F_OK);
+  const raw = await readFile(OUTPUT_FILE, 'utf8');
+  const rows = raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0).length;
+  if (rows <= 0) {
+    throw new Error('NDJSON file is empty');
+  }
+  return rows;
+}
+
+async function main(): Promise<void> {
+  const result = spawnSync(
+    'node',
+    ['dist-examples/07-summary-and-ndjson/run.js'],
+    {
+      env: { ...process.env },
+      encoding: 'utf8',
+      stdio: 'pipe',
+    },
+  );
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (typeof result.status === 'number' && result.status !== 0) {
+    const stderr = result.stderr ? `\n${result.stderr}` : '';
+    throw new Error(`example exited with code ${result.status}${stderr}`);
+  }
+
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+
+  const rows = await ensureNdjson();
+  console.log('EX07_NDJSON_ROWS', rows);
+  console.log('EX07_SUMMARY_SMOKE_OK');
+}
+
+main().catch((err) => {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error('[examples/07-summary-and-ndjson] smoke failed:', message);
+  if (err instanceof Error && err.stack) {
+    console.error(err.stack);
+  }
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- document CLI usage of `--summary` and `--ndjson` together with post-processing tips for NDJSON streams
- add a TypeScript SDK example that streams execution reports to `/tmp/tf.reports.ndjson`, prints an aggregated summary and final stats
- include a smoke test that runs the compiled script and verifies the NDJSON file is created with at least one line

## Testing
- pnpm -w examples:build
- node dist-examples/07-summary-and-ndjson/run.js
- node examples/07-summary-and-ndjson/smoke.ts


------
https://chatgpt.com/codex/tasks/task_e_68cb0d5d82e48320b6a50193b0339475