### PR TITLE
chore(examples-polish-2): safe auto-price ex-03, cleanup tmp dirs ex-05/ex-07, improve smoke logs

### DIFF
--- a/examples/03-accounts-and-orders/smoke.ts
+++ b/examples/03-accounts-and-orders/smoke.ts
@@ -23,22 +23,10 @@ function main(): void {
   if (result.error) {
     throw result.error;
   }
-  if (typeof result.status === 'number' && result.status !== 0) {
-    const stderr = result.stderr ? `\n${result.stderr}` : '';
-    throw new Error(`example exited with code ${result.status}${stderr}`);
-  }
-
   const stdout = result.stdout ?? '';
   const stderr = result.stderr ?? '';
 
-  if (stdout) {
-    process.stdout.write(stdout);
-  }
-  if (stderr) {
-    process.stderr.write(stderr);
-  }
-
-  if (!stdout.includes('ACC_ORDERS_OK')) {
+  const printSnippet = (): void => {
     const stdoutSnippet = stdout.slice(0, 500);
     const stderrSnippet = stderr.slice(0, 500);
     console.error(
@@ -49,7 +37,23 @@ function main(): void {
       '[examples/03-accounts-and-orders] smoke stderr snippet:',
       stderrSnippet.length > 0 ? stderrSnippet : '<empty>',
     );
+  };
+
+  if (typeof result.status === 'number' && result.status !== 0) {
+    printSnippet();
+    throw new Error(`example exited with code ${result.status}`);
+  }
+
+  if (!stdout.includes('ACC_ORDERS_OK')) {
+    printSnippet();
     throw new Error('marker ACC_ORDERS_OK not found in stdout');
+  }
+
+  if (stdout) {
+    process.stdout.write(stdout);
+  }
+  if (stderr) {
+    process.stderr.write(stderr);
   }
   console.log('EX03_ACC_ORDERS_SMOKE_OK');
 }

--- a/examples/05-pause-auto-checkpoint/run.ts
+++ b/examples/05-pause-auto-checkpoint/run.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readdirSync, rmSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import process from 'node:process';
 import { tmpdir } from 'node:os';
@@ -187,7 +187,13 @@ async function main(): Promise<void> {
     }
     if (tempDir) {
       try {
-        rmSync(tempDir, { recursive: true, force: true });
+        if (existsSync(tempDir)) {
+          const contents = readdirSync(tempDir);
+          if (contents.length === 0) {
+            rmSync(tempDir, { recursive: true });
+            logger.info(`removed checkpoint temp dir ${tempDir}`);
+          }
+        }
       } catch (err) {
         logger.debug(
           `failed to remove temp checkpoint dir ${tempDir}: ${

--- a/examples/07-summary-and-ndjson/run.ts
+++ b/examples/07-summary-and-ndjson/run.ts
@@ -1,5 +1,11 @@
 import { once } from 'node:events';
-import { createWriteStream, existsSync, mkdtempSync, rmSync } from 'node:fs';
+import {
+  createWriteStream,
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+} from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import process from 'node:process';
@@ -403,8 +409,12 @@ async function main(): Promise<void> {
   if (!keepNdjson) {
     try {
       rmSync(outputPath, { force: true });
-      if (tempDir) {
-        rmSync(tempDir, { recursive: true, force: true });
+      if (tempDir && existsSync(tempDir)) {
+        const contents = readdirSync(tempDir);
+        if (contents.length === 0) {
+          rmSync(tempDir, { recursive: true });
+          logger.info(`removed NDJSON temp dir ${tempDir}`);
+        }
       }
     } catch (err) {
       logger.warn(


### PR DESCRIPTION
## Summary
- add a `peekFirstTradePrice` helper to inspect the first trade price without advancing the main cursor
- have the accounts-and-orders example reuse the peeked price for ±1% auto quotes with sane fallbacks and improved smoke diagnostics
- ensure the checkpoint and NDJSON examples remove their temporary directories once artifacts are deleted

## Testing
- pnpm -w examples:build
- TF_TRADES_FILES=examples/_smoke/mini-trades.jsonl TF_DEPTH_FILES=examples/_smoke/mini-depth.jsonl node dist-examples/03-accounts-and-orders/run.js
- node examples/03-accounts-and-orders/smoke.ts
- node dist-examples/05-pause-auto-checkpoint/run.js
- node examples/05-pause-auto-checkpoint/smoke.ts
- node dist-examples/07-summary-and-ndjson/run.js
- node examples/07-summary-and-ndjson/smoke.ts

------
https://chatgpt.com/codex/tasks/task_e_68cbc856def483208d925c9dedec9383