### PR TITLE
docs(examples): 02-limits-and-speed (CLI + SDK)

### DIFF
--- a/examples/02-limits-and-speed/README.md
+++ b/examples/02-limits-and-speed/README.md
@@ -1,9 +1,93 @@
-# 02. Limits and Speed
+# 02 — Лимиты длительности и скорость часов
 
-TODO: описать эксперимент с ограничениями и ускоренными часами.
+Продолжаем работать с историческим прогоном, но теперь управляем длительностью
+и скоростью симуляции. Пример показывает, как ограничить работу движка по
+количеству событий, симулируемому времени и реальному wall-времени, а также как
+использовать ускоренные часы.
 
-## Черновик плана
+## Требования
 
-- [ ] Настроить `runScenario` с лимитами по событиям и времени.
-- [ ] Добавить пример работы с `clock: 'accelerated'`.
-- [ ] Обновить README с примерами запуска.
+- Установленные зависимости репозитория (`pnpm install`).
+- Сборка рабочих пакетов (`pnpm -w build`).
+- Мини-файлы с данными из [`examples/_smoke`](../_smoke/).
+
+## Вариант A — CLI
+
+1. Подготовим пути к данным (можно перечислять несколько файлов через запятую):
+
+   ```bash
+   export TF_TRADES_FILES="examples/_smoke/mini-trades.jsonl"
+   export TF_DEPTH_FILES="examples/_smoke/mini-depth.jsonl"
+   ```
+
+2. Запускаем разные варианты симуляции через CLI:
+
+   **Логические часы + ограничение по событиям**
+
+   ```bash
+   pnpm --filter @tradeforge/cli dev -- simulate \
+     --trades "$TF_TRADES_FILES" \
+     --depth "$TF_DEPTH_FILES" \
+     --clock logical \
+     --max-events 10 \
+     --summary
+   ```
+
+   **Ускоренные часы (speed=20) + лимит по сим-времени**
+
+   ```bash
+   pnpm --filter @tradeforge/cli dev -- simulate \
+     --trades "$TF_TRADES_FILES" \
+     --depth "$TF_DEPTH_FILES" \
+     --clock accelerated \
+     --speed 20 \
+     --max-sim-ms 2000 \
+     --summary
+   ```
+
+   **Wall-часы + ограничение по реальному времени исполнения**
+
+   ```bash
+   pnpm --filter @tradeforge/cli dev -- simulate \
+     --trades "$TF_TRADES_FILES" \
+     --depth "$TF_DEPTH_FILES" \
+     --clock wall \
+     --max-wall-ms 1200 \
+     --summary
+   ```
+
+> Сим-время (simulation time) — это диапазон временных меток событий в данных,
+> например `1700000000000…1700000002000` для первых двух сделок. Wall-время
+> измеряется по реальному `Date.now()`. Логические часы обрабатывают события без
+> задержек, ускоренные — масштабируют wall-время (speed ×), а wall-часы
+> синхронизируются с реальным временем один к одному.
+
+## Вариант B — SDK (TypeScript)
+
+1. Собираем примеры (создаст `dist-examples/**`):
+
+   ```bash
+   pnpm -w examples:build
+   ```
+
+2. Запускаем подготовленный скрипт:
+
+   ```bash
+   node dist-examples/02-limits-and-speed/run.js
+   ```
+
+   В stdout появятся три блока `LIMITS_SPEED_RESULT { ... }` — для логических,
+   ускоренных и wall-часов. Итоговый маркер `LIMITS_SPEED_OK` сигнализирует об
+   успешном завершении примера.
+
+## Smoke-проверка
+
+Для локальной проверки можно использовать скрипт:
+
+```bash
+pnpm -w examples:build
+node examples/02-limits-and-speed/smoke.ts
+```
+
+Он запускает скомпилированный SDK-пример и проверяет наличие маркера
+`LIMITS_SPEED_OK`.

--- a/examples/02-limits-and-speed/run.ts
+++ b/examples/02-limits-and-speed/run.ts
@@ -1,0 +1,164 @@
+import { resolve } from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+import {
+  createAcceleratedClock,
+  createLogicalClock,
+  createWallClock,
+  runReplay,
+  type MergedEvent,
+  type ReplayLimits,
+  type ReplayProgress,
+  type SimClock,
+} from '@tradeforge/core';
+import { createLogger } from '../_shared/logging.js';
+import { buildDepthReader, buildTradesReader } from '../_shared/readers.js';
+import { buildMerged } from '../_shared/merge.js';
+
+const logger = createLogger({ prefix: '[examples/02-limits-and-speed]' });
+
+const DATA_ROOT = resolve(process.cwd(), 'examples', '_smoke');
+const TRADES_FILE = resolve(DATA_ROOT, 'mini-trades.jsonl');
+const DEPTH_FILE = resolve(DATA_ROOT, 'mini-depth.jsonl');
+
+type ClockKind = 'logical' | 'accelerated' | 'wall';
+type LimitReason = 'maxEvents' | 'maxSimTimeMs' | 'maxWallTimeMs';
+
+type ClockWithDesc = { clock: SimClock; desc: string };
+
+type RunConfig = {
+  kind: ClockKind;
+  reason: LimitReason;
+  limits: ReplayLimits;
+  acceleratedSpeed?: number;
+};
+
+function formatLimits(limits?: ReplayLimits): string {
+  if (!limits) return '';
+  const parts: string[] = [];
+  if (limits.maxEvents !== undefined) {
+    parts.push(`events<=${limits.maxEvents}`);
+  }
+  if (limits.maxSimTimeMs !== undefined) {
+    parts.push(`sim<=${limits.maxSimTimeMs}ms`);
+  }
+  if (limits.maxWallTimeMs !== undefined) {
+    parts.push(`wall<=${limits.maxWallTimeMs}ms`);
+  }
+  return parts.length > 0 ? ` limits(${parts.join(', ')})` : '';
+}
+
+function computeWallMs(progress: ReplayProgress): number {
+  return Math.max(0, progress.wallLastMs - progress.wallStartMs);
+}
+
+function computeSimMs(progress: ReplayProgress): number {
+  if (progress.simStartTs === undefined || progress.simLastTs === undefined) {
+    return 0;
+  }
+  const start = Number(progress.simStartTs);
+  const end = Number(progress.simLastTs);
+  return Math.max(0, end - start);
+}
+
+function buildClock(kind: ClockKind, speed?: number): ClockWithDesc {
+  if (kind === 'logical') {
+    const clock = createLogicalClock();
+    return { clock, desc: clock.desc() };
+  }
+  if (kind === 'wall') {
+    const clock = createWallClock();
+    return { clock, desc: clock.desc() };
+  }
+  const accelSpeed = speed ?? 20;
+  const clock = createAcceleratedClock(accelSpeed);
+  return { clock, desc: clock.desc() };
+}
+
+function createTimeline(): AsyncIterable<MergedEvent> {
+  const trades = buildTradesReader([TRADES_FILE]);
+  const depth = buildDepthReader([DEPTH_FILE]);
+  return buildMerged(trades, depth);
+}
+
+async function runOnce(config: RunConfig): Promise<void> {
+  const { clock, desc } = buildClock(config.kind, config.acceleratedSpeed);
+  logger.info(
+    `run start kind=${config.kind} reason=${config.reason} clock=${desc}${formatLimits(
+      config.limits,
+    )}`,
+  );
+
+  const progress = await runReplay({
+    timeline: createTimeline(),
+    clock,
+    limits: config.limits,
+    onProgress: (stats: ReplayProgress) => {
+      logger.progress(stats, config.kind);
+    },
+  });
+
+  const result = {
+    kind: config.kind,
+    reason: config.reason,
+    eventsOut: progress.eventsOut,
+    wallMs: computeWallMs(progress),
+    simMs: computeSimMs(progress),
+  };
+
+  logger.info(`run completed kind=${config.kind} events=${progress.eventsOut}`);
+  console.log('LIMITS_SPEED_RESULT', result);
+}
+
+async function runAll(): Promise<void> {
+  const runs: RunConfig[] = [
+    {
+      kind: 'logical',
+      reason: 'maxEvents',
+      limits: { maxEvents: 10 },
+    },
+    {
+      kind: 'accelerated',
+      reason: 'maxSimTimeMs',
+      limits: { maxSimTimeMs: 2000 },
+      acceleratedSpeed: 20,
+    },
+    {
+      kind: 'wall',
+      reason: 'maxWallTimeMs',
+      limits: { maxWallTimeMs: 1200 },
+    },
+  ];
+
+  logger.info(`using trades=${TRADES_FILE}`);
+  logger.info(`using depth=${DEPTH_FILE}`);
+
+  for (const config of runs) {
+    await runOnce(config);
+  }
+
+  console.log('LIMITS_SPEED_OK');
+}
+
+async function main(): Promise<void> {
+  try {
+    await runAll();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('LIMITS_SPEED_FAILED', message);
+    if (err instanceof Error && err.stack) {
+      console.error(err.stack);
+    }
+    process.exit(1);
+  }
+}
+
+const invokedFromCli =
+  process.argv[1] &&
+  pathToFileURL(resolve(process.argv[1])).href === import.meta.url;
+
+if (invokedFromCli) {
+  void main();
+}
+
+export { runAll };

--- a/examples/02-limits-and-speed/smoke.ts
+++ b/examples/02-limits-and-speed/smoke.ts
@@ -1,0 +1,50 @@
+import { spawnSync } from 'node:child_process';
+import process from 'node:process';
+
+function ensureMarker(output: string): void {
+  if (!output.includes('LIMITS_SPEED_OK')) {
+    throw new Error('marker LIMITS_SPEED_OK not found in stdout');
+  }
+}
+
+function main(): void {
+  const result = spawnSync(
+    'node',
+    ['dist-examples/02-limits-and-speed/run.js'],
+    {
+      env: { ...process.env },
+      encoding: 'utf8',
+      stdio: 'pipe',
+    },
+  );
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (typeof result.status === 'number' && result.status !== 0) {
+    const stderr = result.stderr ? `\n${result.stderr}` : '';
+    throw new Error(`example exited with code ${result.status}${stderr}`);
+  }
+
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+
+  ensureMarker(result.stdout ?? '');
+  console.log('EX02_LIMITS_SPEED_SMOKE_OK');
+}
+
+try {
+  main();
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error('[examples/02-limits-and-speed] smoke failed:', message);
+  if (err instanceof Error && err.stack) {
+    console.error(err.stack);
+  }
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- document CLI usage for logical, accelerated and wall clocks with limits in example 02
- add SDK script that runs the replay three times with different limits and emits LIMITS_SPEED markers
- include a smoke test that checks for the LIMITS_SPEED_OK marker after execution

## Testing
- `pnpm -w examples:build`
- `node dist-examples/02-limits-and-speed/run.js`
- `node examples/02-limits-and-speed/smoke.ts`

## Checklist
- [x] README заполнен
- [x] run.ts реализован (3 прогона, 3 лимита)
- [x] smoke.ts добавлен
- [ ] CI зелёный

------
https://chatgpt.com/codex/tasks/task_e_68cbe64687808320b53f1e3362a8aac8