### PR TITLE
docs(examples): 04-stop-orders (CLI + SDK + REST)

### DIFF
--- a/examples/04-stop-orders/README.md
+++ b/examples/04-stop-orders/README.md
@@ -1,9 +1,162 @@
-# 04. Stop Orders
+# 04 — Стоп-ордера (STOP_LIMIT и STOP_MARKET)
 
-TODO: добавить пример со стоп-ордером и активацией триггеров.
+Пример показывает работу стоп-ордеров в TradeForge: постановку `STOP_LIMIT` и `STOP_MARKET`, активацию по цене сделки, частичное исполнение и ручную отмену остатка. Сценарий использует мини-датасет сделок/стакана и выводит итоговый маркер `STOP_ORDERS_OK`.
 
-## Черновик плана
+> Все числовые поля (`qty`, `price`, `triggerPrice`, суммы депозитов) передавайте строками в фиксированной точности (fixed-point).
 
-- [ ] Подготовить данные с триггером стоп-ордера.
-- [ ] Настроить логирование событий активации.
-- [ ] Описать запуск и ожидаемый результат.
+## Требования
+
+- Установленные зависимости (`pnpm install`).
+- Сборка пакетов (`pnpm -w build`).
+- Сборка примеров (`pnpm -w examples:build`) — создаёт `dist-examples/**` для запуска CLI/SDK.
+- Источник данных: JSONL-файлы сделок и стакана. Для демонстрации используем мини-набор из [`examples/_smoke`](../_smoke/).
+
+## CLI — демонстрация активации и отмены
+
+1. Укажем файлы сделок/стакана (скрипт автоматически подставит эти значения, если переменные окружения не заданы):
+
+   ```bash
+   export TF_TRADES_FILES="examples/_smoke/mini-trades.jsonl"
+   export TF_DEPTH_FILES="examples/_smoke/mini-depth.jsonl"
+   ```
+
+2. Собираем и запускаем сценарий:
+
+   ```bash
+   pnpm -w examples:build
+   pnpm examples:run 04-stop-orders
+   ```
+
+   В stdout появятся журнальные сообщения об активации и исполнении ордеров. Финальная строка содержит маркер для автоматизаций:
+
+   ```text
+   STOP_ORDERS_OK { placed: 2, triggered: 2, canceled: 1 }
+   ```
+
+   Значения `triggered` и `canceled` подсчитываются по фактическому статусу `STOP_MARKET` (полностью исполнен) и `STOP_LIMIT` (частично исполнен и отменён вручную).
+
+## SDK (TypeScript) — ключевые шаги
+
+Скрипт [`run.ts`](./run.ts) реализует полный сценарий на SDK:
+
+1. Загружает сделки и стакан через `buildTradesReader`/`buildDepthReader`, объединяет их в `buildMerged`.
+2. Создаёт `ExchangeState` с символом `BTCUSDT`, подключает `AccountsService` и `OrdersService`.
+3. Открывает счёт и зачисляет 0.100 BTC + 2000 USDT (строки автоматически конвертируются в `QtyInt`/`PriceInt`).
+4. Размещает два стоп-ордера:
+   - `STOP_MARKET SELL 0.020 BTC` с `triggerPrice=27000.12` и `triggerDirection=DOWN` — сработает, когда цена сделки опустится ниже порога.
+   - `STOP_LIMIT BUY 0.040 BTC @ 27000.45` с `triggerPrice=27000.50` и `triggerDirection=UP` — активируется при росте цены, дальше работает как лимитный ордер.
+5. Итерация `executeTimeline` отслеживает активацию, логи `fill` и отменяет `STOP_LIMIT`, как только он частично исполнен (остаток остаётся `CANCELED`).
+6. Скрипт печатает финальные статусы для обоих ордеров и маркер `STOP_ORDERS_OK { placed: 2, triggered: 2, canceled: 1 }`.
+
+Запуск собранного скрипта напрямую (переменные окружения аналогичны CLI-варианту):
+
+```bash
+TF_TRADES_FILES="examples/_smoke/mini-trades.jsonl" \
+TF_DEPTH_FILES="examples/_smoke/mini-depth.jsonl" \
+node dist-examples/04-stop-orders/run.js
+```
+
+## REST (curl)
+
+Для работы HTTP API поднимаем сервис:
+
+```bash
+pnpm --filter @tradeforge/svc dev
+```
+
+По умолчанию сервер слушает `http://localhost:3000`. Все числовые поля (`qty`, `price`, `triggerPrice`, суммы депозитов) передаются строками.
+
+### Подготовка счёта
+
+```bash
+ACCOUNT_ID=$(curl -s -X POST http://localhost:3000/v1/accounts | jq -r '.accountId')
+
+# Депозит базовой и котируемой валюты (строки в fixed-point)
+curl -s -X POST "http://localhost:3000/v1/accounts/$ACCOUNT_ID/deposit" \
+  -H "content-type: application/json" \
+  -d '{"currency":"BTC","amount":"0.100"}'
+
+curl -s -X POST "http://localhost:3000/v1/accounts/$ACCOUNT_ID/deposit" \
+  -H "content-type: application/json" \
+  -d '{"currency":"USDT","amount":"2000"}'
+```
+
+### STOP_MARKET (SELL) с триггером вниз
+
+```bash
+STOP_MARKET_ID=$(curl -s -X POST http://localhost:3000/v1/orders \
+  -H "content-type: application/json" \
+  -d '{
+        "accountId": "'"$ACCOUNT_ID"'",
+        "symbol": "BTCUSDT",
+        "type": "STOP_MARKET",
+        "side": "SELL",
+        "qty": "0.020",
+        "triggerPrice": "27000.12",
+        "triggerDirection": "DOWN"
+      }' | jq -r '.id')
+```
+
+### STOP_LIMIT (BUY) с триггером вверх
+
+```bash
+STOP_LIMIT_ID=$(curl -s -X POST http://localhost:3000/v1/orders \
+  -H "content-type: application/json" \
+  -d '{
+        "accountId": "'"$ACCOUNT_ID"'",
+        "symbol": "BTCUSDT",
+        "type": "STOP_LIMIT",
+        "side": "BUY",
+        "qty": "0.040",
+        "price": "27000.45",
+        "triggerPrice": "27000.50",
+        "triggerDirection": "UP"
+      }' | jq -r '.id')
+```
+
+Проверяем текущее состояние и открытые ордера:
+
+```bash
+curl -s "http://localhost:3000/v1/orders/$STOP_LIMIT_ID" | jq
+curl -s "http://localhost:3000/v1/orders/open?accountId=$ACCOUNT_ID&symbol=BTCUSDT" | jq
+```
+
+После частичного исполнения `STOP_LIMIT` можно отменить остаток:
+
+```bash
+curl -s -X DELETE "http://localhost:3000/v1/orders/$STOP_LIMIT_ID" | jq
+```
+
+### Типичные ошибки валидации (400 Bad Request)
+
+```bash
+# price обязателен для STOP_LIMIT
+curl -i -X POST http://localhost:3000/v1/orders \
+  -H "content-type: application/json" \
+  -d '{
+        "accountId": "'"$ACCOUNT_ID"'",
+        "symbol": "BTCUSDT",
+        "type": "STOP_LIMIT",
+        "side": "BUY",
+        "qty": "0.010",
+        "triggerPrice": "27000",
+        "triggerDirection": "UP"
+      }'
+# HTTP/1.1 400 Bad Request
+# {"message":"price is required for STOP_LIMIT"}
+
+# triggerPrice обязателен для всех стоп-ордеров
+curl -i -X POST http://localhost:3000/v1/orders \
+  -H "content-type: application/json" \
+  -d '{
+        "accountId": "'"$ACCOUNT_ID"'",
+        "symbol": "BTCUSDT",
+        "type": "STOP_MARKET",
+        "side": "SELL",
+        "qty": "0.010"
+      }'
+# HTTP/1.1 400 Bad Request
+# {"message":"triggerPrice is required for stop orders"}
+```
+
+`triggerDirection` тоже обязателен для `STOP_LIMIT`/`STOP_MARKET` и должен быть `UP` или `DOWN`. Ответы сервиса сериализуют `bigint` в строки, поэтому поля `price`, `qty`, `triggerPrice`, а также балансы возвращаются строковыми значениями.

--- a/examples/04-stop-orders/run.ts
+++ b/examples/04-stop-orders/run.ts
@@ -1,0 +1,361 @@
+import { resolve } from 'node:path';
+import process from 'node:process';
+import {
+  AccountsService,
+  ExchangeState,
+  OrdersService,
+  StaticMockOrderbook,
+  executeTimeline,
+  fromPriceInt,
+  fromQtyInt,
+  toPriceInt,
+  toQtyInt,
+  type MergedEvent,
+  type Order,
+  type PriceInt,
+  type QtyInt,
+  type SymbolId,
+} from '@tradeforge/core';
+import { buildDepthReader, buildTradesReader } from '../_shared/readers.js';
+import { buildMerged } from '../_shared/merge.js';
+import { createLogger } from '../_shared/logging.js';
+import { createAccountWithDeposit } from '../_shared/accounts.js';
+import { runScenario } from '../_shared/replay.js';
+
+const logger = createLogger({ prefix: '[examples/04-stop-orders]' });
+
+const DEFAULT_SYMBOL = 'BTCUSDT';
+const SYMBOL = (process.env['TF_SYMBOL']?.trim() || DEFAULT_SYMBOL) as SymbolId;
+
+const SYMBOL_CONFIG = {
+  base: 'BTC',
+  quote: 'USDT',
+  priceScale: 5,
+  qtyScale: 6,
+};
+
+const FEE_CONFIG = { makerBps: 0, takerBps: 0 };
+
+function splitFiles(value?: string): string[] {
+  if (!value) return [];
+  return value
+    .split(/[\n,]/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function resolveFileList(
+  envValue: string | undefined,
+  fallback: string[],
+): string[] {
+  const envEntries = splitFiles(envValue);
+  const chosen = envEntries.length > 0 ? envEntries : fallback;
+  return chosen.map((file) => resolve(file));
+}
+
+function formatPrice(value: PriceInt): string {
+  return fromPriceInt(value, SYMBOL_CONFIG.priceScale);
+}
+
+function formatQty(value: QtyInt): string {
+  return fromQtyInt(value, SYMBOL_CONFIG.qtyScale);
+}
+
+function calcRemainingQty(order: Order): QtyInt {
+  const total = order.qty as unknown as bigint;
+  const executed = order.executedQty as unknown as bigint;
+  const remaining = total - executed;
+  const positive = remaining > 0n ? remaining : 0n;
+  return positive as unknown as QtyInt;
+}
+
+type AsyncEventQueue<T> = {
+  iterable: AsyncIterable<T>;
+  push(value: T): void;
+  close(): void;
+};
+
+function createAsyncEventQueue<T>(): AsyncEventQueue<T> {
+  const values: T[] = [];
+  const waiting: Array<(value: IteratorResult<T>) => void> = [];
+  let closed = false;
+
+  const resolveNext = (result: IteratorResult<T>): void => {
+    const resolver = waiting.shift();
+    if (resolver) {
+      resolver(result);
+    }
+  };
+
+  const iterable: AsyncIterable<T> = {
+    [Symbol.asyncIterator](): AsyncIterator<T> {
+      return {
+        next(): Promise<IteratorResult<T>> {
+          if (values.length > 0) {
+            const value = values.shift()!;
+            return Promise.resolve({ value, done: false });
+          }
+          if (closed) {
+            return Promise.resolve({
+              value: undefined as unknown as T,
+              done: true,
+            });
+          }
+          return new Promise((resolveNextValue) => {
+            waiting.push(resolveNextValue);
+          });
+        },
+        return(): Promise<IteratorResult<T>> {
+          closed = true;
+          values.length = 0;
+          while (waiting.length > 0) {
+            resolveNext({ value: undefined as unknown as T, done: true });
+          }
+          return Promise.resolve({
+            value: undefined as unknown as T,
+            done: true,
+          });
+        },
+      } satisfies AsyncIterator<T>;
+    },
+  };
+
+  return {
+    iterable,
+    push(value: T) {
+      if (closed) {
+        return;
+      }
+      if (waiting.length > 0) {
+        resolveNext({ value, done: false });
+        return;
+      }
+      values.push(value);
+    },
+    close() {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      if (waiting.length > 0) {
+        while (waiting.length > 0) {
+          resolveNext({ value: undefined as unknown as T, done: true });
+        }
+      }
+    },
+  } satisfies AsyncEventQueue<T>;
+}
+
+async function main(): Promise<void> {
+  const tradesFiles = resolveFileList(process.env['TF_TRADES_FILES'], [
+    resolve('examples', '_smoke', 'mini-trades.jsonl'),
+  ]);
+  const depthFiles = resolveFileList(process.env['TF_DEPTH_FILES'], [
+    resolve('examples', '_smoke', 'mini-depth.jsonl'),
+  ]);
+
+  logger.info(
+    `using trades=${tradesFiles.join(', ')} depth=${depthFiles.join(', ')}`,
+  );
+
+  const trades = buildTradesReader(tradesFiles);
+  const depth = buildDepthReader(depthFiles);
+  const timeline = buildMerged(trades, depth);
+
+  const state = new ExchangeState({
+    symbols: { [SYMBOL as unknown as string]: SYMBOL_CONFIG },
+    fee: FEE_CONFIG,
+    orderbook: new StaticMockOrderbook({ best: {} }),
+  });
+
+  const accounts = new AccountsService(state);
+  const orders = new OrdersService(state, accounts);
+
+  const baseDeposit = toQtyInt('0.100', SYMBOL_CONFIG.qtyScale);
+  const quoteDeposit = toPriceInt('2000', SYMBOL_CONFIG.priceScale);
+
+  const { account, accountId } = await createAccountWithDeposit(
+    {
+      accounts,
+      symbol: {
+        id: SYMBOL as unknown as string,
+        base: SYMBOL_CONFIG.base,
+        quote: SYMBOL_CONFIG.quote,
+      },
+    },
+    {
+      base: baseDeposit.toString(),
+      quote: quoteDeposit.toString(),
+    },
+  );
+
+  logger.info(
+    `created account ${accountId} -> base=${formatQty(baseDeposit)} ${SYMBOL_CONFIG.base}, quote=${formatPrice(quoteDeposit)} ${SYMBOL_CONFIG.quote}`,
+  );
+
+  const stopMarketQty = toQtyInt('0.020', SYMBOL_CONFIG.qtyScale);
+  const stopMarketTrigger = toPriceInt('27000.12', SYMBOL_CONFIG.priceScale);
+  const stopMarket = orders.placeOrder({
+    accountId: account.id,
+    symbol: SYMBOL,
+    type: 'STOP_MARKET',
+    side: 'SELL',
+    qty: stopMarketQty,
+    triggerPrice: stopMarketTrigger,
+    triggerDirection: 'DOWN',
+  });
+  const stopMarketId = String(stopMarket.id);
+  logger.info(
+    `[${stopMarketId}] placed STOP_MARKET SELL qty=${formatQty(stopMarketQty)} trigger=${formatPrice(stopMarketTrigger)} direction=DOWN`,
+  );
+
+  const stopLimitQty = toQtyInt('0.040', SYMBOL_CONFIG.qtyScale);
+  const stopLimitPrice = toPriceInt('27000.45', SYMBOL_CONFIG.priceScale);
+  const stopLimitTrigger = toPriceInt('27000.50', SYMBOL_CONFIG.priceScale);
+  const stopLimit = orders.placeOrder({
+    accountId: account.id,
+    symbol: SYMBOL,
+    type: 'STOP_LIMIT',
+    side: 'BUY',
+    qty: stopLimitQty,
+    price: stopLimitPrice,
+    triggerPrice: stopLimitTrigger,
+    triggerDirection: 'UP',
+  });
+  const stopLimitId = String(stopLimit.id);
+  logger.info(
+    `[${stopLimitId}] placed STOP_LIMIT BUY qty=${formatQty(stopLimitQty)} limit=${formatPrice(stopLimitPrice)} trigger=${formatPrice(stopLimitTrigger)} direction=UP`,
+  );
+
+  const orderMeta = new Map<string, { label: string }>([
+    [stopMarketId, { label: 'STOP_MARKET SELL' }],
+    [stopLimitId, { label: 'STOP_LIMIT BUY' }],
+  ]);
+  const activationLogged = new Set<string>();
+  let stopLimitCanceled = false;
+
+  const queue = createAsyncEventQueue<MergedEvent>();
+
+  const executionTask = (async () => {
+    for await (const report of executeTimeline(queue.iterable, state)) {
+      if (report.kind === 'END') {
+        break;
+      }
+      if (!report.orderId) {
+        continue;
+      }
+      const key = String(report.orderId);
+      const meta = orderMeta.get(key);
+      const current = orders.getOrder(report.orderId);
+
+      if (current.activated && !activationLogged.has(key)) {
+        activationLogged.add(key);
+        const newType = current.type;
+        logger.info(
+          `[${meta?.label ?? key}] activated -> now type=${newType} status=${current.status}`,
+        );
+      }
+
+      if (report.kind === 'FILL' && report.fill) {
+        const fillQty = formatQty(report.fill.qty);
+        const fillPrice = formatPrice(report.fill.price);
+        logger.info(
+          `[${meta?.label ?? key}] fill qty=${fillQty} price=${fillPrice} status=${current.status}`,
+        );
+
+        if (
+          meta?.label === 'STOP_LIMIT BUY' &&
+          !stopLimitCanceled &&
+          current.status === 'PARTIALLY_FILLED'
+        ) {
+          const canceled = orders.cancelOrder(report.orderId);
+          stopLimitCanceled = true;
+          const executedQty = formatQty(canceled.executedQty);
+          const totalQty = formatQty(canceled.qty);
+          const remainingQty = formatQty(calcRemainingQty(canceled));
+          logger.info(
+            `[${meta.label}] canceled after partial fill -> status=${canceled.status} executed=${executedQty}/${totalQty} remaining=${remainingQty}`,
+          );
+        }
+      }
+    }
+  })();
+
+  let replayError: unknown;
+  let progressEvents: number | undefined;
+  try {
+    const progress = await runScenario({
+      timeline,
+      clock: 'logical',
+      limits: { maxEvents: 64 },
+      logger,
+      onEvent: (event) => {
+        queue.push(event);
+      },
+    });
+    progressEvents = progress.eventsOut;
+  } catch (err) {
+    replayError = err;
+  } finally {
+    queue.close();
+  }
+
+  await executionTask;
+
+  if (progressEvents !== undefined) {
+    logger.info(`timeline replay completed after ${progressEvents} events`);
+  }
+
+  if (replayError) {
+    throw replayError;
+  }
+
+  const finalStopMarket = orders.getOrder(stopMarket.id);
+  const finalStopLimit = orders.getOrder(stopLimit.id);
+
+  const finalTriggered = [finalStopMarket, finalStopLimit].filter(
+    (order) => order.activated,
+  ).length;
+  const finalCanceled = [finalStopMarket, finalStopLimit].filter(
+    (order) => order.status === 'CANCELED',
+  ).length;
+
+  const printOrderSummary = (order: Order, label: string): void => {
+    const executed = formatQty(order.executedQty);
+    const total = formatQty(order.qty);
+    const remaining = formatQty(calcRemainingQty(order));
+    const activation = order.activated ? 'yes' : 'no';
+    const pricePart =
+      order.price !== undefined
+        ? ` price=${formatPrice(order.price)}`
+        : order.type === 'MARKET'
+          ? ' price=MARKET'
+          : '';
+    const triggerPart = order.triggerPrice
+      ? ` trigger=${formatPrice(order.triggerPrice)} direction=${
+          order.triggerDirection ?? '-'
+        }`
+      : '';
+    logger.info(
+      `[${label}] final status=${order.status} activated=${activation} type=${order.type}${pricePart}${triggerPart} executed=${executed}/${total} remaining=${remaining}`,
+    );
+  };
+
+  printOrderSummary(finalStopMarket, 'STOP_MARKET SELL');
+  printOrderSummary(finalStopLimit, 'STOP_LIMIT BUY');
+
+  console.log('STOP_ORDERS_OK', {
+    placed: orderMeta.size,
+    triggered: finalTriggered,
+    canceled: finalCanceled,
+  });
+}
+
+main().catch((err) => {
+  const message = err instanceof Error ? err.message : String(err);
+  logger.error(`stop orders scenario failed: ${message}`);
+  if (err instanceof Error && err.stack) {
+    logger.debug(err.stack);
+  }
+  process.exit(1);
+});

--- a/examples/04-stop-orders/smoke.ts
+++ b/examples/04-stop-orders/smoke.ts
@@ -1,0 +1,68 @@
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import process from 'node:process';
+
+function main(): void {
+  const trades = resolve('examples', '_smoke', 'mini-trades.jsonl');
+  const depth = resolve('examples', '_smoke', 'mini-depth.jsonl');
+
+  const result = spawnSync('node', ['dist-examples/04-stop-orders/run.js'], {
+    env: {
+      ...process.env,
+      TF_TRADES_FILES: process.env['TF_TRADES_FILES'] ?? trades,
+      TF_DEPTH_FILES: process.env['TF_DEPTH_FILES'] ?? depth,
+    },
+    encoding: 'utf8',
+    stdio: 'pipe',
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  const stdout = result.stdout ?? '';
+  const stderr = result.stderr ?? '';
+
+  const printSnippet = (): void => {
+    const stdoutSnippet = stdout.slice(0, 500);
+    const stderrSnippet = stderr.slice(0, 500);
+    console.error(
+      '[examples/04-stop-orders] smoke stdout snippet:',
+      stdoutSnippet.length > 0 ? stdoutSnippet : '<empty>',
+    );
+    console.error(
+      '[examples/04-stop-orders] smoke stderr snippet:',
+      stderrSnippet.length > 0 ? stderrSnippet : '<empty>',
+    );
+  };
+
+  if (typeof result.status === 'number' && result.status !== 0) {
+    printSnippet();
+    throw new Error(`example exited with code ${result.status}`);
+  }
+
+  if (!stdout.includes('STOP_ORDERS_OK')) {
+    printSnippet();
+    throw new Error('marker STOP_ORDERS_OK not found in stdout');
+  }
+
+  if (stdout) {
+    process.stdout.write(stdout);
+  }
+  if (stderr) {
+    process.stderr.write(stderr);
+  }
+
+  console.log('EX04_STOP_ORDERS_SMOKE_OK');
+}
+
+try {
+  main();
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error('[examples/04-stop-orders] smoke failed:', message);
+  if (err instanceof Error && err.stack) {
+    console.error(err.stack);
+  }
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- expand the 04-stop-orders README with CLI/SDK/REST walkthroughs, stop-order tips, and validation examples
- add a TypeScript scenario that places STOP_MARKET and STOP_LIMIT orders, waits for triggers, logs fills, and emits a STOP_ORDERS_OK marker
- introduce a smoke script that runs the built scenario against mini fixtures and verifies the success marker

## Testing
- pnpm -w examples:build
- node dist-examples/04-stop-orders/run.js
- node examples/04-stop-orders/smoke.ts

------
https://chatgpt.com/codex/tasks/task_e_68cbe64de6f88320a6f7883879bb2005