### PR TITLE
docs(examples): 08-rest-mini (curl, ошибки 400, smoke)

### DIFF
--- a/examples/08-rest-mini/README.md
+++ b/examples/08-rest-mini/README.md
@@ -1,9 +1,210 @@
-# 08. REST Mini
+# 08 — Минимальный REST-сценарий
 
-TODO: минимальный REST-сценарий поверх SDK.
+Пример показывает, как с помощью `curl` выполнять базовые операции через сервис [`@tradeforge/svc`](../../apps/svc/README.md): создать аккаунт, пополнить счёт, разместить и отменить ордера. Сценарий рассчитан на локальный запуск без SDK.
 
-## Черновик плана
+> Все числовые значения (`amount`, `qty`, `price`, `triggerPrice`, суммы в балансах) передаются **строками**. Сервис принимает строки, масштабирует их по конфигурации символа и возвращает строки с тем же масштабом.
+> Не забывайте указывать заголовок `content-type: application/json` для запросов с телом.
 
-- [ ] Поднять небольшой HTTP-сервер, использующий симулятор.
-- [ ] Добавить примеры запросов и ответов.
-- [ ] Описать запуск и остановку сервиса.
+## Требования
+
+- `pnpm install` — общие зависимости (если ещё не ставили).
+- Запущенный REST-сервис: `pnpm --filter @tradeforge/svc dev` (по умолчанию слушает `http://localhost:3000`).
+- Утилиты `curl` и `jq` — используются для отправки запросов и форматирования ответов.
+
+Создайте пару переменных окружения для сокращений:
+
+```bash
+export BASE_URL="http://localhost:3000"
+export SYMBOL="BTCUSDT"
+```
+
+## Шаги сценария
+
+### 1. Создать аккаунт
+
+```bash
+ACCOUNT_ID=$(curl -sS -X POST "$BASE_URL/v1/accounts" | jq -r '.accountId')
+echo "ACCOUNT_ID=$ACCOUNT_ID"
+```
+
+Пример ответа:
+
+```json
+{ "accountId": "A1" }
+```
+
+### 2. Пополнить счёт в котируемой валюте
+
+Пополняем баланс на 1000 USDT:
+
+```bash
+curl -sS -X POST "$BASE_URL/v1/accounts/$ACCOUNT_ID/deposit" \
+  -H 'content-type: application/json' \
+  -d '{"currency":"USDT","amount":"1000"}' | jq
+```
+
+Ответ отражает текущее состояние баланса USDT. Значение `free` (`"100000000"`) — это 1000 × 10⁵ (учитывается `priceScale=5` для `BTCUSDT`).
+
+```json
+{
+  "free": "100000000",
+  "locked": "0"
+}
+```
+
+Снимок всех балансов счёта:
+
+```bash
+curl -sS "$BASE_URL/v1/accounts/$ACCOUNT_ID/balances" | jq
+```
+
+```json
+{
+  "USDT": {
+    "free": "100000000",
+    "locked": "0"
+  }
+}
+```
+
+### 3. Разместить LIMIT BUY ордер
+
+Ордер на покупку 0.010 BTC по цене 27 000.40 USDT:
+
+```bash
+LIMIT_JSON=$(curl -sS -X POST "$BASE_URL/v1/orders" \
+  -H 'content-type: application/json' \
+  -d '{
+        "accountId": "'"$ACCOUNT_ID"'",
+        "symbol": "'"$SYMBOL"'",
+        "type": "LIMIT",
+        "side": "BUY",
+        "qty": "0.010",
+        "price": "27000.40"
+      }')
+LIMIT_ID=$(echo "$LIMIT_JSON" | jq -r '.id')
+echo "$LIMIT_JSON" | jq '{id, type, side, qty, price, status, reserved}'
+```
+
+Ожидаемый фрагмент ответа:
+
+```json
+{
+  "id": "O1",
+  "type": "LIMIT",
+  "side": "BUY",
+  "qty": "10000",
+  "price": "2700040000",
+  "status": "OPEN",
+  "reserved": {
+    "currency": "USDT",
+    "total": "27013900",
+    "remaining": "27013900"
+  }
+}
+```
+
+Проверяем статус ордера и список открытых заявок:
+
+```bash
+curl -sS "$BASE_URL/v1/orders/$LIMIT_ID" | jq '{id, status, qty, price}'
+curl -sS "$BASE_URL/v1/orders/open?accountId=$ACCOUNT_ID&symbol=$SYMBOL" | jq 'map({id, type, status})'
+```
+
+### 4. Разместить STOP_MARKET ордер
+
+BUY-стоп без цены (исполнится маркетом после триггера 27 500 USDT):
+
+```bash
+STOP_JSON=$(curl -sS -X POST "$BASE_URL/v1/orders" \
+  -H 'content-type: application/json' \
+  -d '{
+        "accountId": "'"$ACCOUNT_ID"'",
+        "symbol": "'"$SYMBOL"'",
+        "type": "STOP_MARKET",
+        "side": "BUY",
+        "qty": "0.005",
+        "triggerPrice": "27500",
+        "triggerDirection": "UP"
+      }')
+echo "$STOP_JSON" | jq '{id, type, triggerPrice, triggerDirection, status}'
+```
+
+### 5. Отменить LIMIT ордер и проверить балансы
+
+```bash
+curl -sS -X DELETE "$BASE_URL/v1/orders/$LIMIT_ID" | jq '{id, status}'
+curl -sS "$BASE_URL/v1/accounts/$ACCOUNT_ID/balances" | jq '.USDT'
+curl -sS "$BASE_URL/v1/orders/open?accountId=$ACCOUNT_ID&symbol=$SYMBOL" | jq 'map({id, status})'
+```
+
+После отмены поле `locked` по USDT снова становится `"0"`.
+
+## Типичные ошибки валидации (`400 Bad Request`)
+
+### LIMIT без `price`
+
+```bash
+curl -i -sS -X POST "$BASE_URL/v1/orders" \
+  -H 'content-type: application/json' \
+  -d '{
+        "accountId": "'"$ACCOUNT_ID"'",
+        "symbol": "'"$SYMBOL"'",
+        "type": "LIMIT",
+        "side": "BUY",
+        "qty": "0.010"
+      }'
+```
+
+Фрагмент ответа:
+
+```
+HTTP/1.1 400 Bad Request
+{"message":"price is required for LIMIT"}
+```
+
+### STOP\_\* без `triggerPrice`
+
+```bash
+curl -i -sS -X POST "$BASE_URL/v1/orders" \
+  -H 'content-type: application/json' \
+  -d '{
+        "accountId": "'"$ACCOUNT_ID"'",
+        "symbol": "'"$SYMBOL"'",
+        "type": "STOP_MARKET",
+        "side": "SELL",
+        "qty": "0.001"
+      }'
+```
+
+```
+HTTP/1.1 400 Bad Request
+{"message":"triggerPrice is required for stop orders"}
+```
+
+## Скрипт `rest.sh`
+
+Для удобства можно использовать оболочку над `curl`:
+
+```bash
+bash examples/08-rest-mini/rest.sh help
+```
+
+Основные команды:
+
+- `create_account` — POST `/v1/accounts`.
+- `deposit_quote <accountId> <amount> [currency]` — POST `/v1/accounts/:id/deposit`.
+- `place_limit <accountId> <side> <qty> <price> [symbol]` — POST `/v1/orders` с типом `LIMIT`.
+- `place_stop_market <accountId> <side> <qty> <triggerPrice> <triggerDirection> [symbol]` — POST `/v1/orders` с типом `STOP_MARKET`.
+- `list_open <accountId> [symbol]` — GET `/v1/orders/open`.
+- `cancel_by_id <orderId>` — DELETE `/v1/orders/:id`.
+
+Скрипт выводит JSON-ответы сервиса (если установлен `jq`, то в отформатированном виде). Переменные `BASE_URL` и `SYMBOL` берутся из окружения, как и в примерах выше.
+
+## Смоук-тест
+
+`smoke.ts` проверяет доступность сервиса и создание аккаунта. Если `BASE_URL` недостижим (сервис не запущен), скрипт выводит подсказку и завершает работу с кодом `0`, чтобы не падать в CI. При доступном сервисе выводится маркер `REST_MINI_SMOKE_OK <accountId>`.
+
+```bash
+node examples/08-rest-mini/smoke.ts
+```

--- a/examples/08-rest-mini/rest.sh
+++ b/examples/08-rest-mini/rest.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:3000}"
+SYMBOL="${SYMBOL:-BTCUSDT}"
+
+usage() {
+  cat <<USAGE
+Usage: ${0##*/} <command> [args...]
+
+Commands:
+  create_account
+  deposit_quote <accountId> <amount> [currency]
+  place_limit <accountId> <side> <qty> <price> [symbol]
+  place_stop_market <accountId> <side> <qty> <triggerPrice> <triggerDirection> [symbol]
+  list_open <accountId> [symbol]
+  cancel_by_id <orderId>
+
+Environment:
+  BASE_URL (default http://localhost:3000)
+  SYMBOL   (default BTCUSDT)
+USAGE
+}
+
+print_json() {
+  local body="$1"
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s\n' "$body" | jq
+  else
+    printf '%s\n' "$body"
+  fi
+}
+
+join_url() {
+  local path="$1"
+  if [[ "$path" == /* ]]; then
+    printf '%s%s' "${BASE_URL%/}" "$path"
+  else
+    printf '%s/%s' "${BASE_URL%/}" "$path"
+  fi
+}
+
+create_account() {
+  local response
+  response=$(curl -sS -X POST "$(join_url '/v1/accounts')")
+  print_json "$response"
+}
+
+deposit_quote() {
+  if [[ $# -lt 2 ]]; then
+    echo "usage: deposit_quote <accountId> <amount> [currency]" >&2
+    return 1
+  fi
+  local account_id="$1"
+  local amount="$2"
+  local currency="${3:-USDT}"
+  local payload
+  printf -v payload '{"currency":"%s","amount":"%s"}' "$currency" "$amount"
+  local response
+  response=$(curl -sS -X POST "$(join_url "/v1/accounts/${account_id}/deposit")" \
+    -H 'content-type: application/json' \
+    -d "$payload")
+  print_json "$response"
+}
+
+place_limit() {
+  if [[ $# -lt 4 ]]; then
+    echo "usage: place_limit <accountId> <side> <qty> <price> [symbol]" >&2
+    return 1
+  fi
+  local account_id="$1"
+  local side="${2^^}"
+  local qty="$3"
+  local price="$4"
+  local symbol="${5:-$SYMBOL}"
+  local payload
+  printf -v payload '{"accountId":"%s","symbol":"%s","type":"LIMIT","side":"%s","qty":"%s","price":"%s"}' \
+    "$account_id" "$symbol" "$side" "$qty" "$price"
+  local response
+  response=$(curl -sS -X POST "$(join_url '/v1/orders')" \
+    -H 'content-type: application/json' \
+    -d "$payload")
+  print_json "$response"
+}
+
+place_stop_market() {
+  if [[ $# -lt 5 ]]; then
+    echo "usage: place_stop_market <accountId> <side> <qty> <triggerPrice> <triggerDirection> [symbol]" >&2
+    return 1
+  fi
+  local account_id="$1"
+  local side="${2^^}"
+  local qty="$3"
+  local trigger_price="$4"
+  local trigger_direction="${5^^}"
+  local symbol="${6:-$SYMBOL}"
+  local payload
+  printf -v payload '{"accountId":"%s","symbol":"%s","type":"STOP_MARKET","side":"%s","qty":"%s","triggerPrice":"%s","triggerDirection":"%s"}' \
+    "$account_id" "$symbol" "$side" "$qty" "$trigger_price" "$trigger_direction"
+  local response
+  response=$(curl -sS -X POST "$(join_url '/v1/orders')" \
+    -H 'content-type: application/json' \
+    -d "$payload")
+  print_json "$response"
+}
+
+list_open() {
+  if [[ $# -lt 1 ]]; then
+    echo "usage: list_open <accountId> [symbol]" >&2
+    return 1
+  fi
+  local account_id="$1"
+  local symbol="${2:-$SYMBOL}"
+  local url
+  printf -v url '%s' "$(join_url "/v1/orders/open?accountId=${account_id}&symbol=${symbol}")"
+  local response
+  response=$(curl -sS "$url")
+  print_json "$response"
+}
+
+cancel_by_id() {
+  if [[ $# -lt 1 ]]; then
+    echo "usage: cancel_by_id <orderId>" >&2
+    return 1
+  fi
+  local order_id="$1"
+  local response
+  response=$(curl -sS -X DELETE "$(join_url "/v1/orders/${order_id}")")
+  print_json "$response"
+}
+
+if [[ $# -eq 0 || "$1" == 'help' || "$1" == '--help' ]]; then
+  usage
+  exit 0
+fi
+
+command="$1"
+shift
+
+case "$command" in
+  create_account)
+    create_account "$@"
+    ;;
+  deposit_quote)
+    deposit_quote "$@"
+    ;;
+  place_limit)
+    place_limit "$@"
+    ;;
+  place_stop_market)
+    place_stop_market "$@"
+    ;;
+  list_open)
+    list_open "$@"
+    ;;
+  cancel_by_id)
+    cancel_by_id "$@"
+    ;;
+  *)
+    echo "unknown command: $command" >&2
+    usage
+    exit 1
+    ;;
+esac

--- a/examples/08-rest-mini/smoke.ts
+++ b/examples/08-rest-mini/smoke.ts
@@ -1,0 +1,70 @@
+import process from 'node:process';
+
+const BASE_URL = process.env['BASE_URL'] ?? 'http://localhost:3000';
+
+function buildUrl(path: string): string {
+  return new URL(path, BASE_URL).toString();
+}
+
+async function isReachable(): Promise<boolean> {
+  try {
+    await fetch(buildUrl('/'));
+    return true;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[examples/08-rest-mini] fetch to ${BASE_URL} failed: ${message}`,
+    );
+    return false;
+  }
+}
+
+async function createAccount(): Promise<string> {
+  const response = await fetch(buildUrl('/v1/accounts'), { method: 'POST' });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(
+      `failed to create account: status ${response.status} ${response.statusText}. Body: ${text}`,
+    );
+  }
+  let payload: unknown;
+  const contentType = response.headers.get('content-type') ?? '';
+  if (contentType.includes('application/json')) {
+    payload = await response.json();
+  } else {
+    const text = await response.text();
+    throw new Error(
+      `unexpected content-type: ${contentType || 'unknown'}, body: ${text}`,
+    );
+  }
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('account response is not an object');
+  }
+  const accountId = (payload as Record<string, unknown>)['accountId'];
+  if (typeof accountId !== 'string' || accountId.length === 0) {
+    throw new Error('accountId missing in response');
+  }
+  return accountId;
+}
+
+async function main(): Promise<void> {
+  const reachable = await isReachable();
+  if (!reachable) {
+    console.log(
+      `[examples/08-rest-mini] svc is not reachable at ${BASE_URL}. Start it with: pnpm --filter @tradeforge/svc dev`,
+    );
+    return;
+  }
+
+  const accountId = await createAccount();
+  console.log(`REST_MINI_SMOKE_OK {"accountId":"${accountId}"}`);
+}
+
+main().catch((err) => {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error('[examples/08-rest-mini] smoke failed:', message);
+  if (err instanceof Error && err.stack) {
+    console.error(err.stack);
+  }
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- расширил README примером запуска REST-сценария: создание аккаунта, депозит, LIMIT/STOP-заявки и ошибки 400
- добавил скрипт `rest.sh` с обёртками над curl (BASE_URL/SYMBOL из окружения)
- добавил `smoke.ts`, который проверяет доступность сервиса и создание аккаунта без падения при остановленном SVC

## Testing
- pnpm -w --reporter append-only examples:build
- bash examples/08-rest-mini/rest.sh
- node examples/08-rest-mini/smoke.ts
- pnpm --filter @tradeforge/svc dev & node examples/08-rest-mini/smoke.ts (svc online)

------
https://chatgpt.com/codex/tasks/task_e_68cbe660bd088320b0715cc86e5f8f20