### PR TITLE
chore(examples-touchups-2): reason type (ex-02), safe stop triggers (ex-04), normalized inputs (ex-06), strict REST preflight (ex-08)

### DIFF
--- a/examples/02-limits-and-speed/run.ts
+++ b/examples/02-limits-and-speed/run.ts
@@ -24,11 +24,13 @@ const DEPTH_FILE = resolve(DATA_ROOT, 'mini-depth.jsonl');
 type ClockKind = 'logical' | 'accelerated' | 'wall';
 type ClockWithDesc = { clock: SimClock; desc: string };
 
+type StopReason = 'maxEvents' | 'maxSimTimeMs' | 'maxWallTimeMs' | 'completed';
+
 type RunConfig = {
   kind: ClockKind;
   limits: ReplayLimits;
   acceleratedSpeed?: number;
-  expectedStop?: 'maxEvents' | 'maxSimTimeMs' | 'maxWallTimeMs';
+  expectedStop?: Exclude<StopReason, 'completed'>;
 };
 
 function formatLimits(limits?: ReplayLimits): string {
@@ -137,7 +139,7 @@ async function runOnce(config: RunConfig): Promise<void> {
   };
 
   logger.info(`run completed kind=${config.kind} events=${progress.eventsOut}`);
-  const reason = result.stoppedBy?.maxEvents
+  const reason: StopReason = result.stoppedBy?.maxEvents
     ? 'maxEvents'
     : result.stoppedBy?.maxSimTimeMs
       ? 'maxSimTimeMs'


### PR DESCRIPTION
## Summary
- standardize the stop reason union in the limits/speed example so logs always emit a known value
- extract a safe trigger helper for the stop-orders example and reuse it for auto/fallback pricing
- normalize checkpoint input names in the resume example and tighten the REST mini script’s response validation

## Testing
- pnpm -w examples:build
- node dist-examples/02-limits-and-speed/run.js
- node dist-examples/04-stop-orders/run.js
- node dist-examples/06-resume-from-checkpoint/save.js
- TF_CP_PATH=/tmp/tf-ex06-6cCqd5/checkpoint.v1.json node dist-examples/06-resume-from-checkpoint/resume.js
- node examples/06-resume-from-checkpoint/smoke.ts
- bash examples/08-rest-mini/rest.sh 2>/dev/null || true

------
https://chatgpt.com/codex/tasks/task_e_68cc0344f4948320880ecb00e2de8c8c