### PR TITLE
docs(examples): 09-bot-skeleton (SDK EMA bot, reconcile, NDJSON, smoke)

### DIFF
--- a/examples/09-bot-skeleton/README.md
+++ b/examples/09-bot-skeleton/README.md
@@ -1,0 +1,47 @@
+# 09 — Bot Skeleton (SDK)
+
+Минимальный пример торгового бота на SDK TradeForge. Бот читает таймлайн торгов и стаканов, считает две EMA, строит намерение на единственный лимитный ордер и через reconcile приводит открытые заявки к желаемому состоянию. Исполнения учитываются в метриках; итог выводится строкой `BOT_OK { ... }`.
+
+## Быстрый старт
+
+```bash
+pnpm -w examples:build
+TF_TRADES_FILES="examples/_smoke/mini-trades.jsonl" \
+TF_DEPTH_FILES="examples/_smoke/mini-depth.jsonl" \
+TF_CLOCK=logical TF_MAX_EVENTS=1000 TF_QTY="0.001" \
+node dist-examples/09-bot-skeleton/run.js
+```
+
+Ожидаемый вывод: строка `BOT_OK { ... }` с полями `fills`, `fees`, `finalBalances`, `pnl`.
+
+## ENV (все строки)
+
+- `TF_SYMBOL=BTCUSDT` (по умолчанию)
+- `TF_TRADES_FILES` / `TF_DEPTH_FILES` — пути к JSONL-таймлайнам
+- `TF_SEED=42`
+- `TF_EMA_FAST=12`, `TF_EMA_SLOW=26`, `TF_SPREAD_BPS=5`
+- `TF_QTY="0.001"`
+- `TF_CLOCK=logical|accelerated|wall` (+ `TF_SPEED`), `TF_MAX_EVENTS`/`TF_MAX_SIM_MS`/`TF_MAX_WALL_MS`
+- `TF_VERBOSE=1`, `TF_NDJSON_PATH=/tmp/tf.bot.ndjson`
+
+## Что делает бот
+
+1. Читает торговые и стаканные события, объединяет их в таймлайн.
+2. Поддерживает best bid/ask, mid и последнюю цену сделки.
+3. Считает две EMA и определяет сигнал BUY/SELL/FLAT.
+4. Строит намерение (`BUY` ниже mid или `SELL` выше mid), приводит его к открытому ордеру через `reconcile`.
+5. Проверяет доступные средства, учитывает комиссию и исполненные сделки.
+6. Пишет действия и исполнения в NDJSON (если задан `TF_NDJSON_PATH`).
+7. Завершает работу строкой `BOT_OK { ... }` с финальными метриками.
+
+## NDJSON постобработка
+
+```bash
+jq -c '{ts, kind, action, fill}' /tmp/tf.bot.ndjson | head
+```
+
+Каждая строка — JSON с полями `ts`, `kind`, `action` (для действий бота) и `fill` (для исполнений).
+
+## Fixed-point
+
+Числовые значения передавайте строками; внутри используются `bigint` с масштабами `priceScale=5` и `qtyScale=6`.

--- a/examples/09-bot-skeleton/lib/book.ts
+++ b/examples/09-bot-skeleton/lib/book.ts
@@ -1,0 +1,148 @@
+import type {
+  DepthEvent,
+  MergedEvent,
+  PriceInt,
+  TradeEvent,
+} from '@tradeforge/core';
+
+export interface BookState {
+  bestBid?: PriceInt;
+  bestAsk?: PriceInt;
+  lastTrade?: PriceInt;
+  mid?: PriceInt;
+  bids: Map<bigint, bigint>;
+  asks: Map<bigint, bigint>;
+}
+
+function setBookPrice(
+  state: BookState,
+  key: 'bestBid' | 'bestAsk' | 'mid',
+  value: PriceInt | undefined,
+): void {
+  if (value === undefined) {
+    delete state[key];
+    return;
+  }
+  state[key] = value;
+}
+
+function toRawPrice(value: PriceInt | undefined): bigint | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return value as unknown as bigint;
+}
+
+function toRawQty(value: bigint): bigint {
+  return value < 0n ? 0n : value;
+}
+
+function toPrice(value: bigint | undefined): PriceInt | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return value as unknown as PriceInt;
+}
+
+function updateMid(state: BookState): void {
+  const bid = toRawPrice(state.bestBid);
+  const ask = toRawPrice(state.bestAsk);
+  if (bid !== undefined && ask !== undefined) {
+    setBookPrice(state, 'mid', toPrice((bid + ask) / 2n));
+    return;
+  }
+  if (bid !== undefined) {
+    setBookPrice(state, 'mid', toPrice(bid));
+    return;
+  }
+  if (ask !== undefined) {
+    setBookPrice(state, 'mid', toPrice(ask));
+    return;
+  }
+  if (state.lastTrade !== undefined) {
+    setBookPrice(state, 'mid', state.lastTrade);
+    return;
+  }
+  setBookPrice(state, 'mid', undefined);
+}
+
+function applyDepthLevels(
+  levels: Map<bigint, bigint>,
+  updates: DepthEvent['payload']['bids'],
+  priceSelector: (level: DepthEvent['payload']['bids'][number]) => PriceInt,
+  qtySelector: (level: DepthEvent['payload']['bids'][number]) => bigint,
+): void {
+  for (const level of updates) {
+    const price = priceSelector(level) as unknown as bigint;
+    const qty = toRawQty(qtySelector(level));
+    if (qty <= 0n) {
+      levels.delete(price);
+    } else {
+      levels.set(price, qty);
+    }
+  }
+}
+
+function computeBest(
+  levels: Map<bigint, bigint>,
+  pick: (current: bigint | undefined, price: bigint) => bigint,
+): bigint | undefined {
+  let best: bigint | undefined;
+  for (const [price, qty] of levels.entries()) {
+    if (qty <= 0n) {
+      levels.delete(price);
+      continue;
+    }
+    best = pick(best, price);
+  }
+  return best;
+}
+
+function applyDepth(state: BookState, event: DepthEvent): void {
+  applyDepthLevels(
+    state.bids,
+    event.payload.bids,
+    (level) => level.price,
+    (level) => level.qty as unknown as bigint,
+  );
+  applyDepthLevels(
+    state.asks,
+    event.payload.asks,
+    (level) => level.price,
+    (level) => level.qty as unknown as bigint,
+  );
+  const bestBid = computeBest(state.bids, (current, price) =>
+    current === undefined || price > current ? price : current,
+  );
+  const bestAsk = computeBest(state.asks, (current, price) =>
+    current === undefined || price < current ? price : current,
+  );
+  setBookPrice(state, 'bestBid', toPrice(bestBid));
+  setBookPrice(state, 'bestAsk', toPrice(bestAsk));
+  updateMid(state);
+}
+
+function applyTrade(state: BookState, event: TradeEvent): void {
+  state.lastTrade = event.payload.price;
+  if (!state.mid) {
+    state.mid = event.payload.price;
+  } else if (state.bestBid === undefined && state.bestAsk === undefined) {
+    state.mid = event.payload.price;
+  }
+}
+
+export function createBookState(): BookState {
+  return {
+    bids: new Map<bigint, bigint>(),
+    asks: new Map<bigint, bigint>(),
+  } satisfies BookState;
+}
+
+export function updateBook(state: BookState, event: MergedEvent): void {
+  if (event.kind === 'depth') {
+    applyDepth(state, event);
+    return;
+  }
+  applyTrade(state, event);
+  updateMid(state);
+}

--- a/examples/09-bot-skeleton/lib/intent.ts
+++ b/examples/09-bot-skeleton/lib/intent.ts
@@ -1,0 +1,80 @@
+export type OrderIntentSide = 'BUY' | 'SELL';
+
+export interface OrderIntent {
+  side: OrderIntentSide;
+  price: string;
+  qty: string;
+}
+
+export interface ExistingOrderView extends OrderIntent {
+  id: string;
+}
+
+export type IntentAction =
+  | { kind: 'place'; intent: OrderIntent }
+  | { kind: 'cancel'; orderId: string }
+  | { kind: 'replace'; orderId: string; intent: OrderIntent };
+
+export interface ReconcileParams {
+  want?: OrderIntent;
+  existing?: ExistingOrderView;
+  lastActionTs?: number;
+  now: number;
+  minActionGapMs: number;
+}
+
+export interface ReconcileResult {
+  actions: IntentAction[];
+  nextActionTs?: number;
+}
+
+function sameIntent(a?: OrderIntent, b?: OrderIntent): boolean {
+  if (!a || !b) {
+    return false;
+  }
+  return a.side === b.side && a.price === b.price && a.qty === b.qty;
+}
+
+export function reconcile(params: ReconcileParams): ReconcileResult {
+  const { want, existing, now, lastActionTs, minActionGapMs } = params;
+  if (
+    lastActionTs !== undefined &&
+    now - lastActionTs < Math.max(0, minActionGapMs)
+  ) {
+    return { actions: [] };
+  }
+  if (!want && !existing) {
+    return { actions: [] };
+  }
+  if (!want && existing) {
+    return {
+      actions: [{ kind: 'cancel', orderId: existing.id }],
+      nextActionTs: now,
+    };
+  }
+  if (want && !existing) {
+    return {
+      actions: [{ kind: 'place', intent: want }],
+      nextActionTs: now,
+    };
+  }
+  if (!existing || !want) {
+    return { actions: [] };
+  }
+  if (sameIntent(want, existing)) {
+    return { actions: [] };
+  }
+  if (want.side !== existing.side) {
+    return {
+      actions: [
+        { kind: 'cancel', orderId: existing.id },
+        { kind: 'place', intent: want },
+      ],
+      nextActionTs: now,
+    };
+  }
+  return {
+    actions: [{ kind: 'replace', orderId: existing.id, intent: want }],
+    nextActionTs: now,
+  };
+}

--- a/examples/09-bot-skeleton/lib/metrics.ts
+++ b/examples/09-bot-skeleton/lib/metrics.ts
@@ -1,0 +1,149 @@
+import type {
+  Balances,
+  ExecutionReport,
+  PriceInt,
+  QtyInt,
+} from '@tradeforge/core';
+
+export interface MetricsFinalizeParams {
+  balances: Record<string, Balances>;
+  baseCurrency: string;
+  quoteCurrency: string;
+  priceScale: number;
+  qtyScale: number;
+  lastPrice?: PriceInt;
+  initialQuote: bigint;
+}
+
+export interface MetricsSummary {
+  fills: number;
+  fees: { maker: string; taker: string; total: string };
+  ordersPlaced: number;
+  cancels: number;
+  finalBalances: Record<string, { free: string; locked: string }>;
+  pnl: string;
+}
+
+interface FeeTotals {
+  maker: bigint;
+  taker: bigint;
+}
+
+function toRaw(value: PriceInt | QtyInt | undefined): bigint | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return value as unknown as bigint;
+}
+
+function formatScaled(value: bigint, scale: number): string {
+  const negative = value < 0n;
+  const abs = negative ? -value : value;
+  if (scale <= 0) {
+    return `${negative ? '-' : ''}${abs.toString(10)}`;
+  }
+  const padded = abs.toString(10).padStart(scale + 1, '0');
+  const intPart = padded.slice(0, -scale) || '0';
+  const fracPart = padded.slice(-scale).replace(/0+$/, '');
+  const body = fracPart.length > 0 ? `${intPart}.${fracPart}` : intPart;
+  return negative ? `-${body}` : body;
+}
+
+function formatBalance(
+  balance: Balances,
+  scale: number,
+): {
+  free: string;
+  locked: string;
+} {
+  const freeStr = formatScaled(balance.free, scale);
+  const lockedStr = formatScaled(balance.locked, scale);
+  return { free: freeStr, locked: lockedStr };
+}
+
+function ensureBalance(
+  balances: Record<string, Balances>,
+  currency: string,
+): Balances {
+  const entry = balances[currency];
+  if (!entry) {
+    return { free: 0n, locked: 0n } satisfies Balances;
+  }
+  return entry;
+}
+
+export function createMetrics() {
+  const fees: FeeTotals = { maker: 0n, taker: 0n };
+  const perOrderFees = new Map<string, FeeTotals>();
+  let fills = 0;
+  let ordersPlaced = 0;
+  let cancels = 0;
+
+  function onPlace(): void {
+    ordersPlaced += 1;
+  }
+
+  function onCancel(): void {
+    cancels += 1;
+  }
+
+  function onFill(report: ExecutionReport): void {
+    if (report.kind !== 'FILL') {
+      return;
+    }
+    fills += 1;
+    if (!report.orderId || !report.patch?.fees) {
+      return;
+    }
+    const key = String(report.orderId);
+    const prev = perOrderFees.get(key) ?? { maker: 0n, taker: 0n };
+    const maker = report.patch.fees.maker ?? 0n;
+    const taker = report.patch.fees.taker ?? 0n;
+    const deltaMaker = maker - prev.maker;
+    const deltaTaker = taker - prev.taker;
+    if (deltaMaker !== 0n) {
+      fees.maker += deltaMaker;
+    }
+    if (deltaTaker !== 0n) {
+      fees.taker += deltaTaker;
+    }
+    perOrderFees.set(key, { maker, taker });
+  }
+
+  function finalize(params: MetricsFinalizeParams): MetricsSummary {
+    const baseBalance = ensureBalance(params.balances, params.baseCurrency);
+    const quoteBalance = ensureBalance(params.balances, params.quoteCurrency);
+    const baseTotal = baseBalance.free + baseBalance.locked;
+    const quoteTotal = quoteBalance.free + quoteBalance.locked;
+    const lastPriceRaw = toRaw(params.lastPrice) ?? 0n;
+    const denom = 10n ** BigInt(params.qtyScale);
+    const baseValue =
+      lastPriceRaw > 0n && baseTotal > 0n
+        ? (lastPriceRaw * baseTotal) / denom
+        : 0n;
+    const finalQuote = quoteTotal;
+    const pnlRaw = baseValue + finalQuote - params.initialQuote;
+
+    const finalBalances: MetricsSummary['finalBalances'] = {
+      [params.baseCurrency]: formatBalance(baseBalance, params.qtyScale),
+      [params.quoteCurrency]: formatBalance(quoteBalance, params.priceScale),
+    };
+
+    const totalFees = fees.maker + fees.taker;
+
+    return {
+      fills,
+      fees: {
+        maker: formatScaled(fees.maker, params.priceScale),
+        taker: formatScaled(fees.taker, params.priceScale),
+        total: formatScaled(totalFees, params.priceScale),
+      },
+      ordersPlaced,
+      cancels,
+      finalBalances,
+      pnl: formatScaled(pnlRaw, params.priceScale),
+    };
+  }
+
+  return { onPlace, onCancel, onFill, finalize };
+}

--- a/examples/09-bot-skeleton/run.ts
+++ b/examples/09-bot-skeleton/run.ts
@@ -1,0 +1,727 @@
+import { once } from 'node:events';
+import { createWriteStream } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import process from 'node:process';
+
+import {
+  AccountsService,
+  ExchangeState,
+  OrdersService,
+  StaticMockOrderbook,
+  createAcceleratedClock,
+  createLogicalClock,
+  createWallClock,
+  executeTimeline,
+  fromPriceInt,
+  fromQtyInt,
+  runReplay,
+  toPriceInt,
+  toQtyInt,
+  type Balances,
+  type MergedEvent,
+  type OrderId,
+  type PriceInt,
+  type QtyInt,
+  type ReplayLimits,
+  type ReplayProgress,
+  type SimClock,
+  type SymbolId,
+} from '@tradeforge/core';
+
+import { createAccountWithDeposit } from '../_shared/accounts.js';
+import { buildMerged } from '../_shared/merge.js';
+import { buildDepthReader, buildTradesReader } from '../_shared/readers.js';
+import { createBookState, updateBook } from './lib/book.js';
+import { createMetrics } from './lib/metrics.js';
+import {
+  reconcile,
+  type ExistingOrderView,
+  type OrderIntent,
+} from './lib/intent.js';
+import {
+  capQtyByBalance,
+  canPlace,
+  type RiskContext,
+} from './strategy/risk.js';
+import {
+  resolveSignal,
+  updateEma,
+  type CrossSignal,
+  type EmaTracker,
+} from './strategy/ema.js';
+
+const DEFAULT_SYMBOL = 'BTCUSDT';
+const DEFAULT_TRADES = ['examples/_smoke/mini-trades.jsonl'];
+const DEFAULT_DEPTH = ['examples/_smoke/mini-depth.jsonl'];
+const DEFAULT_QTY = '0.001';
+const DEFAULT_SPREAD_BPS = 5;
+const DEFAULT_EMA_FAST = 12;
+const DEFAULT_EMA_SLOW = 26;
+const DEFAULT_SEED = 42;
+const MIN_ACTION_INTERVAL_MS = 200;
+
+const SYMBOL_CONFIG = {
+  base: 'BTC',
+  quote: 'USDT',
+  priceScale: 5,
+  qtyScale: 6,
+};
+
+const FEE_CONFIG = {
+  makerBps: 5,
+  takerBps: 7,
+};
+
+interface NdjsonLogger {
+  write(entry: unknown): void;
+  close(): Promise<void>;
+}
+
+interface BotConfig {
+  symbol: SymbolId;
+  tradesFiles: string[];
+  depthFiles: string[];
+  qty: string;
+  spreadBps: number;
+  emaFast: number;
+  emaSlow: number;
+  seed: number;
+  clock: 'logical' | 'accelerated' | 'wall';
+  speed?: number;
+  limits: ReplayLimits;
+  verbose: boolean;
+  ndjsonPath?: string;
+}
+
+interface AsyncEventQueue<T> {
+  iterable: AsyncIterable<T>;
+  push(value: T): void;
+  close(): void;
+}
+
+function createAsyncEventQueue<T>(): AsyncEventQueue<T> {
+  const values: T[] = [];
+  const waiters: Array<(value: IteratorResult<T>) => void> = [];
+  let closed = false;
+
+  const iterator: AsyncIterable<T> = {
+    [Symbol.asyncIterator](): AsyncIterator<T> {
+      return {
+        next(): Promise<IteratorResult<T>> {
+          if (values.length > 0) {
+            const value = values.shift()!;
+            return Promise.resolve({ value, done: false });
+          }
+          if (closed) {
+            return Promise.resolve({
+              value: undefined as unknown as T,
+              done: true,
+            });
+          }
+          return new Promise<IteratorResult<T>>((resolve) => {
+            waiters.push(resolve);
+          });
+        },
+        return(): Promise<IteratorResult<T>> {
+          closed = true;
+          values.length = 0;
+          while (waiters.length > 0) {
+            const resolve = waiters.shift();
+            resolve?.({ value: undefined as unknown as T, done: true });
+          }
+          return Promise.resolve({
+            value: undefined as unknown as T,
+            done: true,
+          });
+        },
+      } satisfies AsyncIterator<T>;
+    },
+  };
+
+  return {
+    iterable: iterator,
+    push(value: T) {
+      if (closed) {
+        return;
+      }
+      const waiter = waiters.shift();
+      if (waiter) {
+        waiter({ value, done: false });
+        return;
+      }
+      values.push(value);
+    },
+    close() {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      while (waiters.length > 0) {
+        const waiter = waiters.shift();
+        waiter?.({ value: undefined as unknown as T, done: true });
+      }
+    },
+  } satisfies AsyncEventQueue<T>;
+}
+
+function parseEnvString(key: string): string | undefined {
+  const raw = process.env[key];
+  if (typeof raw !== 'string') {
+    return undefined;
+  }
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parseEnvInt(key: string, fallback: number): number {
+  const raw = parseEnvString(key);
+  if (!raw) {
+    return fallback;
+  }
+  const num = Number.parseInt(raw, 10);
+  if (!Number.isFinite(num)) {
+    return fallback;
+  }
+  return num;
+}
+
+function parseClock(value?: string): BotConfig['clock'] {
+  if (!value) {
+    return 'logical';
+  }
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'wall') {
+    return 'wall';
+  }
+  if (normalized === 'accelerated') {
+    return 'accelerated';
+  }
+  return 'logical';
+}
+
+function parseFileList(key: string, fallback: string[]): string[] {
+  const raw = parseEnvString(key);
+  if (!raw) {
+    return fallback;
+  }
+  const parts = raw
+    .split(/[\n,]/)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+  return parts.length > 0 ? parts : fallback;
+}
+
+function createPrng(seed: number): () => number {
+  let t = seed >>> 0 || 1;
+  return () => {
+    t += 0x6d2b79f5;
+    let r = Math.imul(t ^ (t >>> 15), t | 1);
+    r ^= r + Math.imul(r ^ (r >>> 7), r | 61);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+async function createNdjsonLogger(path: string): Promise<NdjsonLogger> {
+  const resolved = resolve(path);
+  const dir = dirname(resolved);
+  await mkdir(dir, { recursive: true });
+  const stream = createWriteStream(resolved, { encoding: 'utf8' });
+  let closed = false;
+  return {
+    write(entry: unknown) {
+      if (closed) {
+        return;
+      }
+      stream.write(`${JSON.stringify(entry)}\n`);
+    },
+    async close() {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      stream.end();
+      await once(stream, 'close');
+    },
+  } satisfies NdjsonLogger;
+}
+
+function buildLimits(): ReplayLimits {
+  const maxEventsRaw = parseEnvString('TF_MAX_EVENTS');
+  const maxSimRaw = parseEnvString('TF_MAX_SIM_MS');
+  const maxWallRaw = parseEnvString('TF_MAX_WALL_MS');
+  const limits: ReplayLimits = {};
+  if (maxEventsRaw) {
+    const value = Number(maxEventsRaw);
+    if (Number.isFinite(value) && value > 0) {
+      limits.maxEvents = Math.floor(value);
+    }
+  }
+  if (maxSimRaw) {
+    const value = Number(maxSimRaw);
+    if (Number.isFinite(value) && value > 0) {
+      limits.maxSimTimeMs = value;
+    }
+  }
+  if (maxWallRaw) {
+    const value = Number(maxWallRaw);
+    if (Number.isFinite(value) && value > 0) {
+      limits.maxWallTimeMs = value;
+    }
+  }
+  return limits;
+}
+
+function loadConfig(): BotConfig {
+  const symbolRaw = parseEnvString('TF_SYMBOL') ?? DEFAULT_SYMBOL;
+  const symbol = symbolRaw as SymbolId;
+  const tradesFiles = parseFileList('TF_TRADES_FILES', DEFAULT_TRADES);
+  const depthFiles = parseFileList('TF_DEPTH_FILES', DEFAULT_DEPTH);
+  const qty = parseEnvString('TF_QTY') ?? DEFAULT_QTY;
+  const spreadBps = Math.max(
+    0,
+    parseEnvInt('TF_SPREAD_BPS', DEFAULT_SPREAD_BPS),
+  );
+  const emaFast = Math.max(1, parseEnvInt('TF_EMA_FAST', DEFAULT_EMA_FAST));
+  const emaSlow = Math.max(1, parseEnvInt('TF_EMA_SLOW', DEFAULT_EMA_SLOW));
+  const seed = parseEnvInt('TF_SEED', DEFAULT_SEED);
+  const clock = parseClock(parseEnvString('TF_CLOCK'));
+  const speedRaw = parseEnvString('TF_SPEED');
+  const limits = buildLimits();
+  const verbose = parseEnvString('TF_VERBOSE') === '1';
+  const ndjsonPath = parseEnvString('TF_NDJSON_PATH');
+  const base: BotConfig = {
+    symbol,
+    tradesFiles,
+    depthFiles,
+    qty,
+    spreadBps,
+    emaFast,
+    emaSlow,
+    seed,
+    clock,
+    limits,
+    verbose,
+  };
+  const speedValue = speedRaw ? Number(speedRaw) : undefined;
+  if (
+    Number.isFinite(speedValue) &&
+    speedValue !== undefined &&
+    speedValue > 0
+  ) {
+    base.speed = speedValue;
+  }
+  if (ndjsonPath) {
+    base.ndjsonPath = ndjsonPath;
+  }
+  return base;
+}
+
+function buildClock(
+  clockKind: BotConfig['clock'],
+  speed?: number,
+): {
+  clock: SimClock;
+  desc: string;
+} {
+  if (clockKind === 'wall') {
+    const clock = createWallClock();
+    return { clock, desc: clock.desc() };
+  }
+  if (clockKind === 'accelerated') {
+    const effectiveSpeed = speed && speed > 0 ? speed : undefined;
+    const clock = createAcceleratedClock(effectiveSpeed ?? 10);
+    return { clock, desc: clock.desc() };
+  }
+  const clock = createLogicalClock();
+  return { clock, desc: clock.desc() };
+}
+
+function formatPrice(value: PriceInt): string {
+  return fromPriceInt(value, SYMBOL_CONFIG.priceScale);
+}
+
+function formatQty(value: QtyInt): string {
+  return fromQtyInt(value, SYMBOL_CONFIG.qtyScale);
+}
+
+function applySpread(
+  mid: PriceInt,
+  spreadBps: number,
+  side: 'BUY' | 'SELL',
+): PriceInt {
+  const base = 10000n;
+  const spread = BigInt(Math.max(0, spreadBps));
+  const midRaw = mid as unknown as bigint;
+  const effective =
+    side === 'BUY' ? base - (spread > base ? base : spread) : base + spread;
+  const adjusted = (midRaw * effective) / base;
+  const safe = adjusted <= 0n ? 1n : adjusted;
+  return safe as unknown as PriceInt;
+}
+
+function buildExistingOrder(
+  order:
+    | {
+        id: unknown;
+        side: 'BUY' | 'SELL';
+        price?: PriceInt;
+        qty: QtyInt;
+      }
+    | undefined,
+): ExistingOrderView | undefined {
+  if (!order || order.price === undefined) {
+    return undefined;
+  }
+  return {
+    id: String(order.id ?? ''),
+    side: order.side,
+    price: formatPrice(order.price),
+    qty: formatQty(order.qty),
+  } satisfies ExistingOrderView;
+}
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+  const prng = createPrng(config.seed);
+  const sessionId = Math.floor(prng() * 1e9)
+    .toString(16)
+    .padStart(8, '0');
+
+  const tradeReader = buildTradesReader(config.tradesFiles);
+  const depthReader = buildDepthReader(config.depthFiles);
+  const timeline = buildMerged(tradeReader, depthReader);
+
+  const exchange = new ExchangeState({
+    symbols: { [config.symbol as unknown as string]: SYMBOL_CONFIG },
+    fee: FEE_CONFIG,
+    orderbook: new StaticMockOrderbook({ best: {} }),
+  });
+  const accounts = new AccountsService(exchange);
+  const orders = new OrdersService(exchange, accounts);
+
+  const quoteDeposit = toPriceInt('1000', SYMBOL_CONFIG.priceScale);
+  const quoteDepositRaw = quoteDeposit as unknown as bigint;
+  const { account } = await createAccountWithDeposit(
+    {
+      accounts,
+      symbol: {
+        id: config.symbol,
+        base: SYMBOL_CONFIG.base,
+        quote: SYMBOL_CONFIG.quote,
+      },
+    },
+    { quote: quoteDepositRaw.toString(10) },
+  );
+
+  const metrics = createMetrics();
+  const book = createBookState();
+  const emaFast: EmaTracker = { window: config.emaFast };
+  const emaSlow: EmaTracker = { window: config.emaSlow };
+  let lastSignal: CrossSignal = 'FLAT';
+  let lastActionTs: number | undefined;
+
+  const queue = createAsyncEventQueue<MergedEvent>();
+  let ndjsonLogger: NdjsonLogger | undefined;
+
+  const executionTask = (async () => {
+    for await (const report of executeTimeline(queue.iterable, exchange)) {
+      if (report.kind === 'FILL') {
+        metrics.onFill(report);
+        if (config.verbose && report.fill) {
+          const priceStr = formatPrice(report.fill.price);
+          const qtyStr = formatQty(report.fill.qty);
+          console.log(
+            '[bot] fill',
+            JSON.stringify({
+              orderId: report.orderId ? String(report.orderId) : undefined,
+              side: report.fill.side,
+              price: priceStr,
+              qty: qtyStr,
+              liquidity: report.fill.liquidity,
+            }),
+          );
+        }
+        if (report.fill && ndjsonLogger) {
+          ndjsonLogger.write({
+            ts: Number(report.ts ?? 0),
+            kind: 'fill',
+            session: sessionId,
+            orderId: report.orderId ? String(report.orderId) : undefined,
+            fill: {
+              side: report.fill.side,
+              price: formatPrice(report.fill.price),
+              qty: formatQty(report.fill.qty),
+              liquidity: report.fill.liquidity,
+              tradeRef: report.fill.tradeRef,
+            },
+          });
+        }
+      }
+    }
+  })();
+
+  if (config.ndjsonPath) {
+    ndjsonLogger = await createNdjsonLogger(config.ndjsonPath);
+  }
+
+  const desiredQty = toQtyInt(config.qty, SYMBOL_CONFIG.qtyScale);
+  const limits = config.limits;
+  const { clock } = buildClock(config.clock, config.speed);
+
+  let replayError: unknown;
+  let progress: ReplayProgress | undefined;
+
+  try {
+    progress = await runReplay({
+      timeline,
+      clock,
+      limits: {
+        ...limits,
+      },
+      onEvent: async (event: MergedEvent) => {
+        queue.push(event);
+        updateBook(book, event);
+
+        const mid = book.mid ?? book.lastTrade;
+        if (!mid) {
+          return;
+        }
+
+        const fast = updateEma(emaFast, mid);
+        const slow = updateEma(emaSlow, mid);
+        const signal = resolveSignal(fast, slow);
+        if (signal !== lastSignal && config.verbose) {
+          console.log(
+            '[bot] signal-change',
+            JSON.stringify({
+              ts: Number(event.ts),
+              previous: lastSignal,
+              next: signal,
+            }),
+          );
+        }
+        lastSignal = signal;
+
+        const midStr = formatPrice(mid);
+
+        const openOrders = orders.listOpenOrders(account.id, config.symbol);
+        const existing = buildExistingOrder(openOrders[0]);
+
+        const baseBalance = accounts.getBalance(account.id, SYMBOL_CONFIG.base);
+        const quoteBalance = accounts.getBalance(
+          account.id,
+          SYMBOL_CONFIG.quote,
+        );
+        const riskContext: RiskContext = {
+          balances: { base: baseBalance, quote: quoteBalance },
+          qtyScale: SYMBOL_CONFIG.qtyScale,
+          makerFeeBps: FEE_CONFIG.makerBps,
+        };
+
+        let desired: OrderIntent | undefined;
+        if (signal !== 'FLAT') {
+          const price = applySpread(mid, config.spreadBps, signal);
+          const cappedQty = capQtyByBalance(
+            desiredQty,
+            price,
+            signal,
+            riskContext,
+          );
+          if (canPlace(signal, riskContext, cappedQty, price)) {
+            desired = {
+              side: signal,
+              price: formatPrice(price),
+              qty: formatQty(cappedQty),
+            };
+          }
+        }
+
+        const now = Number(event.ts);
+        const reconcileInput: Parameters<typeof reconcile>[0] = {
+          now,
+          minActionGapMs: MIN_ACTION_INTERVAL_MS,
+          ...(lastActionTs !== undefined ? { lastActionTs } : {}),
+          ...(desired ? { want: desired } : {}),
+          ...(existing ? { existing } : {}),
+        };
+        const { actions, nextActionTs } = reconcile(reconcileInput);
+
+        if (config.verbose) {
+          console.log(
+            '[bot] decision',
+            JSON.stringify({
+              ts: now,
+              mid: midStr,
+              signal,
+              desired,
+              existing,
+              actions: actions.map((action) => action.kind),
+            }),
+          );
+        }
+
+        if (actions.length === 0) {
+          return;
+        }
+
+        for (const action of actions) {
+          if (action.kind === 'cancel') {
+            orders.cancelOrder(action.orderId as unknown as OrderId);
+            metrics.onCancel();
+            if (ndjsonLogger) {
+              ndjsonLogger.write({
+                ts: now,
+                kind: 'action',
+                session: sessionId,
+                action: { type: 'cancel', orderId: action.orderId },
+              });
+            }
+            continue;
+          }
+          if (action.kind === 'replace') {
+            orders.cancelOrder(action.orderId as unknown as OrderId);
+            metrics.onCancel();
+            if (ndjsonLogger) {
+              ndjsonLogger.write({
+                ts: now,
+                kind: 'action',
+                session: sessionId,
+                action: {
+                  type: 'cancel',
+                  orderId: action.orderId,
+                  reason: 'replace',
+                },
+              });
+            }
+            const priceInt = toPriceInt(
+              action.intent.price,
+              SYMBOL_CONFIG.priceScale,
+            );
+            const qtyInt = toQtyInt(action.intent.qty, SYMBOL_CONFIG.qtyScale);
+            const placed = orders.placeOrder({
+              accountId: account.id,
+              symbol: config.symbol,
+              type: 'LIMIT',
+              side: action.intent.side,
+              price: priceInt,
+              qty: qtyInt,
+            });
+            metrics.onPlace();
+            if (ndjsonLogger) {
+              ndjsonLogger.write({
+                ts: now,
+                kind: 'action',
+                session: sessionId,
+                action: {
+                  type: 'place',
+                  mode: 'replace',
+                  orderId: String(placed.id),
+                  side: placed.side,
+                  price: action.intent.price,
+                  qty: action.intent.qty,
+                },
+              });
+            }
+            continue;
+          }
+          if (action.kind === 'place') {
+            const priceInt = toPriceInt(
+              action.intent.price,
+              SYMBOL_CONFIG.priceScale,
+            );
+            const qtyInt = toQtyInt(action.intent.qty, SYMBOL_CONFIG.qtyScale);
+            const placed = orders.placeOrder({
+              accountId: account.id,
+              symbol: config.symbol,
+              type: 'LIMIT',
+              side: action.intent.side,
+              price: priceInt,
+              qty: qtyInt,
+            });
+            metrics.onPlace();
+            if (ndjsonLogger) {
+              ndjsonLogger.write({
+                ts: now,
+                kind: 'action',
+                session: sessionId,
+                action: {
+                  type: 'place',
+                  orderId: String(placed.id),
+                  side: placed.side,
+                  price: action.intent.price,
+                  qty: action.intent.qty,
+                },
+              });
+            }
+          }
+        }
+
+        lastActionTs = nextActionTs;
+      },
+    });
+  } catch (err) {
+    replayError = err;
+  } finally {
+    queue.close();
+  }
+
+  try {
+    await executionTask;
+  } catch (err) {
+    if (!replayError) {
+      replayError = err;
+    }
+  }
+
+  if (replayError) {
+    throw replayError;
+  }
+
+  const balances = accounts.getBalancesSnapshot(account.id);
+  const lastPrice = book.lastTrade ?? book.mid;
+  const finalizeParams: Parameters<typeof metrics.finalize>[0] = {
+    balances: balances as Record<string, Balances>,
+    baseCurrency: SYMBOL_CONFIG.base,
+    quoteCurrency: SYMBOL_CONFIG.quote,
+    priceScale: SYMBOL_CONFIG.priceScale,
+    qtyScale: SYMBOL_CONFIG.qtyScale,
+    initialQuote: quoteDepositRaw,
+    ...(lastPrice !== undefined ? { lastPrice } : {}),
+  };
+  const summary = metrics.finalize(finalizeParams);
+
+  if (ndjsonLogger) {
+    ndjsonLogger.write({
+      ts: Date.now(),
+      kind: 'summary',
+      session: sessionId,
+      summary,
+    });
+    await ndjsonLogger.close();
+  }
+
+  const payload = JSON.stringify(summary);
+  console.log(`BOT_OK ${payload}`);
+
+  if (config.verbose && progress) {
+    const wallMs = Math.max(0, progress.wallLastMs - progress.wallStartMs);
+    const simMs =
+      progress.simStartTs !== undefined && progress.simLastTs !== undefined
+        ? Math.max(0, Number(progress.simLastTs) - Number(progress.simStartTs))
+        : 0;
+    console.log(
+      '[bot] replay',
+      JSON.stringify({ events: progress.eventsOut, wallMs, simMs }),
+    );
+  }
+}
+
+main().catch((err) => {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error('BOT_FAILED', message);
+  if (err instanceof Error && err.stack) {
+    console.error(err.stack);
+  }
+  process.exit(1);
+});

--- a/examples/09-bot-skeleton/smoke.ts
+++ b/examples/09-bot-skeleton/smoke.ts
@@ -1,0 +1,100 @@
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import process from 'node:process';
+
+function ensureField(payload: Record<string, unknown>, field: string): void {
+  if (!(field in payload)) {
+    throw new Error(`payload missing field ${field}`);
+  }
+}
+
+function main(): void {
+  const trades = resolve('examples', '_smoke', 'mini-trades.jsonl');
+  const depth = resolve('examples', '_smoke', 'mini-depth.jsonl');
+
+  const result = spawnSync('node', ['dist-examples/09-bot-skeleton/run.js'], {
+    env: {
+      ...process.env,
+      TF_TRADES_FILES: process.env['TF_TRADES_FILES'] ?? trades,
+      TF_DEPTH_FILES: process.env['TF_DEPTH_FILES'] ?? depth,
+      TF_CLOCK: process.env['TF_CLOCK'] ?? 'logical',
+      TF_MAX_EVENTS: process.env['TF_MAX_EVENTS'] ?? '1000',
+      TF_QTY: process.env['TF_QTY'] ?? '0.001',
+    },
+    encoding: 'utf8',
+    stdio: 'pipe',
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  const stdout = result.stdout ?? '';
+  const stderr = result.stderr ?? '';
+
+  const printSnippet = (): void => {
+    const stdoutSnippet = stdout.slice(0, 600) || '<empty>';
+    const stderrSnippet = stderr.slice(0, 600) || '<empty>';
+    console.error('[examples/09-bot-skeleton] stdout snippet:', stdoutSnippet);
+    console.error('[examples/09-bot-skeleton] stderr snippet:', stderrSnippet);
+  };
+
+  if (typeof result.status === 'number' && result.status !== 0) {
+    printSnippet();
+    throw new Error(`example exited with code ${result.status}`);
+  }
+
+  const match = stdout.match(/BOT_OK\s+({.+})/);
+  if (!match) {
+    printSnippet();
+    throw new Error('BOT_OK marker not found in stdout');
+  }
+
+  const payloadSource = match[1];
+  if (!payloadSource) {
+    printSnippet();
+    throw new Error('BOT_OK payload missing JSON body');
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(payloadSource);
+  } catch (err) {
+    printSnippet();
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`failed to parse BOT_OK payload: ${message}`);
+  }
+
+  if (!payload || typeof payload !== 'object') {
+    printSnippet();
+    throw new Error('BOT_OK payload must be an object');
+  }
+
+  const objectPayload = payload as Record<string, unknown>;
+  ensureField(objectPayload, 'fills');
+  ensureField(objectPayload, 'fees');
+  ensureField(objectPayload, 'ordersPlaced');
+  ensureField(objectPayload, 'cancels');
+  ensureField(objectPayload, 'finalBalances');
+  ensureField(objectPayload, 'pnl');
+
+  if (stdout) {
+    process.stdout.write(stdout);
+  }
+  if (stderr) {
+    process.stderr.write(stderr);
+  }
+
+  console.log('EX09_BOT_SMOKE_OK');
+}
+
+try {
+  main();
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error('[examples/09-bot-skeleton] smoke failed:', message);
+  if (err instanceof Error && err.stack) {
+    console.error(err.stack);
+  }
+  process.exit(1);
+}

--- a/examples/09-bot-skeleton/strategy/ema.ts
+++ b/examples/09-bot-skeleton/strategy/ema.ts
@@ -1,0 +1,57 @@
+import type { PriceInt } from '@tradeforge/core';
+
+export type CrossSignal = 'BUY' | 'SELL' | 'FLAT';
+
+export interface EmaTracker {
+  window: number;
+  current?: PriceInt;
+}
+
+function toRaw(value: PriceInt | undefined): bigint | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return value as unknown as bigint;
+}
+
+function toPriceInt(value: bigint): PriceInt {
+  return value as unknown as PriceInt;
+}
+
+export function updateEma(tracker: EmaTracker, price: PriceInt): PriceInt {
+  const priceRaw = price as unknown as bigint;
+  const prev = toRaw(tracker.current);
+  if (prev === undefined) {
+    tracker.current = price;
+    return price;
+  }
+  const window = tracker.window <= 0 ? 1 : tracker.window;
+  const numerator = (priceRaw - prev) * 2n;
+  const denominator = BigInt(window + 1);
+  const delta = denominator === 0n ? 0n : numerator / denominator;
+  const next = prev + delta;
+  const nextInt = toPriceInt(next);
+  tracker.current = nextInt;
+  return nextInt;
+}
+
+export function resolveSignal(
+  fast?: PriceInt,
+  slow?: PriceInt,
+  epsilon: bigint = 0n,
+): CrossSignal {
+  const fastRaw = toRaw(fast);
+  const slowRaw = toRaw(slow);
+  if (fastRaw === undefined || slowRaw === undefined) {
+    return 'FLAT';
+  }
+  const threshold = epsilon < 0n ? 0n : epsilon;
+  const diff = fastRaw - slowRaw;
+  if (diff > threshold) {
+    return 'BUY';
+  }
+  if (diff < -threshold) {
+    return 'SELL';
+  }
+  return 'FLAT';
+}

--- a/examples/09-bot-skeleton/strategy/risk.ts
+++ b/examples/09-bot-skeleton/strategy/risk.ts
@@ -1,0 +1,118 @@
+import type { Balances, PriceInt, QtyInt, Side } from '@tradeforge/core';
+
+export interface RiskContext {
+  balances: {
+    base: Balances;
+    quote: Balances;
+  };
+  qtyScale: number;
+  makerFeeBps: number;
+}
+
+function toRawQty(value: QtyInt): bigint {
+  return value as unknown as bigint;
+}
+
+function toRawPrice(value: PriceInt): bigint {
+  return value as unknown as bigint;
+}
+
+function pow10(exp: number): bigint {
+  if (!Number.isFinite(exp) || exp < 0) {
+    return 1n;
+  }
+  return 10n ** BigInt(exp);
+}
+
+function clampQty(value: bigint): QtyInt {
+  return (value < 0n ? 0n : value) as unknown as QtyInt;
+}
+
+function calcTotalCost(
+  priceRaw: bigint,
+  qtyRaw: bigint,
+  qtyScale: number,
+  makerFeeBps: number,
+): bigint {
+  if (priceRaw <= 0n || qtyRaw <= 0n) {
+    return 0n;
+  }
+  const denom = pow10(qtyScale);
+  if (denom === 0n) {
+    return 0n;
+  }
+  const notional = (priceRaw * qtyRaw) / denom;
+  const feeMultiplier = makerFeeBps > 0 ? BigInt(makerFeeBps) : 0n;
+  const fee = feeMultiplier === 0n ? 0n : (notional * feeMultiplier) / 10000n;
+  return notional + fee;
+}
+
+export function capQtyByBalance(
+  qty: QtyInt,
+  price: PriceInt,
+  side: Side,
+  ctx: RiskContext,
+): QtyInt {
+  const qtyRaw = toRawQty(qty);
+  if (qtyRaw <= 0n) {
+    return clampQty(qtyRaw);
+  }
+  if (side === 'SELL') {
+    const available = ctx.balances.base.free;
+    if (available <= 0n) {
+      return clampQty(0n);
+    }
+    const capped = qtyRaw > available ? available : qtyRaw;
+    return clampQty(capped);
+  }
+  const priceRaw = toRawPrice(price);
+  if (priceRaw <= 0n) {
+    return clampQty(0n);
+  }
+  const availableQuote = ctx.balances.quote.free;
+  if (availableQuote <= 0n) {
+    return clampQty(0n);
+  }
+  const denom = pow10(ctx.qtyScale);
+  const feeMultiplier = BigInt(10000 + Math.max(0, ctx.makerFeeBps));
+  if (feeMultiplier <= 0n) {
+    return clampQty(0n);
+  }
+  const numerator = availableQuote * 10000n * denom;
+  const denominator = priceRaw * feeMultiplier;
+  if (denominator <= 0n) {
+    return clampQty(0n);
+  }
+  const maxQty = numerator / denominator;
+  if (maxQty <= 0n) {
+    return clampQty(0n);
+  }
+  const capped = qtyRaw > maxQty ? maxQty : qtyRaw;
+  return clampQty(capped);
+}
+
+export function canPlace(
+  side: Side,
+  ctx: RiskContext,
+  qty: QtyInt,
+  price?: PriceInt,
+): boolean {
+  const qtyRaw = toRawQty(qty);
+  if (qtyRaw <= 0n) {
+    return false;
+  }
+  if (side === 'SELL') {
+    return ctx.balances.base.free >= qtyRaw;
+  }
+  if (!price) {
+    return false;
+  }
+  const priceRaw = toRawPrice(price);
+  const required = calcTotalCost(
+    priceRaw,
+    qtyRaw,
+    ctx.qtyScale,
+    ctx.makerFeeBps,
+  );
+  return required > 0n && ctx.balances.quote.free >= required;
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "examples:run": "node --enable-source-maps examples/_shared/bin/run-scenario.ts",
     "examples:ex01": "node dist-examples/01-basic-replay/run.js",
     "examples:ex01:build": "tsc -p tsconfig.examples.json --incremental",
-    "examples:ex01:smoke": "node examples/01-basic-replay/smoke.ts"
+    "examples:ex01:smoke": "node examples/01-basic-replay/smoke.ts",
+    "examples:ex09": "node dist-examples/09-bot-skeleton/run.js",
+    "examples:ex09:smoke": "node examples/09-bot-skeleton/smoke.ts"
   },
   "devDependencies": {
     "@types/jest": "^29.5.11",


### PR DESCRIPTION
## Summary
- add the new 09-bot-skeleton SDK example with README guidance
- implement EMA-based strategy, intent reconciliation helpers, and metrics tracking with optional NDJSON logging
- provide smoke test runner and package scripts for the scenario

## Testing
- `pnpm -w examples:build`
- `TF_TRADES_FILES=examples/_smoke/mini-trades.jsonl TF_DEPTH_FILES=examples/_smoke/mini-depth.jsonl TF_CLOCK=logical TF_MAX_EVENTS=1000 TF_QTY=0.001 node dist-examples/09-bot-skeleton/run.js`
- `node examples/09-bot-skeleton/smoke.ts`

## Checklist
- [x] README добавлен
- [x] run.ts реализован
- [x] strategy/ema.ts и risk.ts добавлены
- [x] lib/intent.ts, lib/book.ts, lib/metrics.ts добавлены
- [x] smoke.ts добавлен
- [x] Опциональный NDJSON поддержан
- [x] CI зелёный

------
https://chatgpt.com/codex/tasks/task_e_68cc14bba52083209da91291017fb998