### PR TITLE
chore(ex-09-bot-polish): deterministic RNG, fixed-point safety, sim-time debounce, risk checks, robust NDJSON, docs & smoke

### DIFF
--- a/examples/09-bot-skeleton/README.md
+++ b/examples/09-bot-skeleton/README.md
@@ -14,15 +14,27 @@ node dist-examples/09-bot-skeleton/run.js
 
 Ожидаемый вывод: строка `BOT_OK { ... }` с полями `fills`, `fees`, `finalBalances`, `pnl`.
 
-## ENV (все строки)
+## ENV
 
-- `TF_SYMBOL=BTCUSDT` (по умолчанию)
-- `TF_TRADES_FILES` / `TF_DEPTH_FILES` — пути к JSONL-таймлайнам
-- `TF_SEED=42`
-- `TF_EMA_FAST=12`, `TF_EMA_SLOW=26`, `TF_SPREAD_BPS=5`
-- `TF_QTY="0.001"`
-- `TF_CLOCK=logical|accelerated|wall` (+ `TF_SPEED`), `TF_MAX_EVENTS`/`TF_MAX_SIM_MS`/`TF_MAX_WALL_MS`
-- `TF_VERBOSE=1`, `TF_NDJSON_PATH=/tmp/tf.bot.ndjson`
+| VAR                                                  | type       | default                             | meaning                             |
+| ---------------------------------------------------- | ---------- | ----------------------------------- | ----------------------------------- |
+| `TF_SYMBOL`                                          | string     | `BTCUSDT`                           | символ для торговли                 |
+| `TF_TRADES_FILES`                                    | csv/string | `examples/_smoke/mini-trades.jsonl` | список trade-таймлайнов             |
+| `TF_DEPTH_FILES`                                     | csv/string | `examples/_smoke/mini-depth.jsonl`  | список depth-таймлайнов             |
+| `TF_SEED`                                            | int        | `42`                                | seed для детерминированного PRNG    |
+| `TF_EMA_FAST` / `TF_EMA_SLOW`                        | int        | `12` / `26`                         | окна EMA                            |
+| `TF_SPREAD_BPS`                                      | int        | `5`                                 | спред в б.п. относительно mid       |
+| `TF_QTY`                                             | string     | `0.001`                             | желаемый объём заявки (fixed-point) |
+| `TF_CLOCK`                                           | enum       | `logical`                           | `logical` / `accelerated` / `wall`  |
+| `TF_SPEED`                                           | number     | –                                   | ускорение для `accelerated` clock   |
+| `TF_MAX_EVENTS` / `TF_MAX_SIM_MS` / `TF_MAX_WALL_MS` | int        | –                                   | лимиты реплея                       |
+| `TF_MIN_ACTION_MS`                                   | int        | `200`                               | анти-дребезг по сим-времени         |
+| `TF_REPLACE_AS_CANCEL_PLACE`                         | flag `0/1` | `0`                                 | форсить replace как cancel+place    |
+| `TF_VERBOSE`                                         | flag `0/1` | `0`                                 | расширенные логи решений и сделок   |
+| `TF_NDJSON_PATH`                                     | path       | –                                   | писать действия/сводку в NDJSON     |
+| `TF_KEEP_NDJSON`                                     | flag `0/1` | `0`                                 | сохранить NDJSON после завершения   |
+
+> Числовые значения передавайте строками: внутри SDK хранится `bigint` с масштабами `priceScale=5` и `qtyScale=6`.
 
 ## Что делает бот
 
@@ -37,11 +49,8 @@ node dist-examples/09-bot-skeleton/run.js
 ## NDJSON постобработка
 
 ```bash
-jq -c '{ts, kind, action, fill}' /tmp/tf.bot.ndjson | head
+TF_NDJSON_PATH="/tmp/tf.bot.ndjson" node dist-examples/09-bot-skeleton/run.js
+jq -r '.kind' /tmp/tf.bot.ndjson | sort | uniq -c
 ```
 
-Каждая строка — JSON с полями `ts`, `kind`, `action` (для действий бота) и `fill` (для исполнений).
-
-## Fixed-point
-
-Числовые значения передавайте строками; внутри используются `bigint` с масштабами `priceScale=5` и `qtyScale=6`.
+Каждая строка NDJSON содержит `ts`, `kind`, `action` и `fill`; удобно быстро посмотреть статистику по событиям через `jq`.

--- a/examples/09-bot-skeleton/lib/book.ts
+++ b/examples/09-bot-skeleton/lib/book.ts
@@ -2,14 +2,18 @@ import type {
   DepthEvent,
   MergedEvent,
   PriceInt,
+  QtyInt,
   TradeEvent,
 } from '@tradeforge/core';
+
+import { isIntString, toBigIntOr } from './fixed.js';
 
 export interface BookState {
   bestBid?: PriceInt;
   bestAsk?: PriceInt;
   lastTrade?: PriceInt;
   mid?: PriceInt;
+  marketReady: boolean;
   bids: Map<bigint, bigint>;
   asks: Map<bigint, bigint>;
 }
@@ -26,17 +30,34 @@ function setBookPrice(
   state[key] = value;
 }
 
-function toRawPrice(value: PriceInt | undefined): bigint | undefined {
+function normalizeInt(
+  value: PriceInt | QtyInt | bigint | undefined,
+): bigint | undefined {
   if (value === undefined) {
     return undefined;
   }
-  return value as unknown as bigint;
+  const raw = value as unknown as bigint;
+  const str = raw.toString(10);
+  if (!isIntString(str)) {
+    return undefined;
+  }
+  return toBigIntOr(str, 0n);
 }
 
-function toRawQty(value: bigint): bigint {
-  return value < 0n ? 0n : value;
+function toRawPrice(value: PriceInt | undefined): bigint | undefined {
+  return normalizeInt(value);
 }
 
+function toRawQty(value: QtyInt | bigint | undefined): bigint | undefined {
+  const normalized = normalizeInt(value);
+  if (normalized === undefined) {
+    return undefined;
+  }
+  return normalized < 0n ? 0n : normalized;
+}
+
+function toPrice(value: bigint): PriceInt;
+function toPrice(value: bigint | undefined): PriceInt | undefined;
 function toPrice(value: bigint | undefined): PriceInt | undefined {
   if (value === undefined) {
     return undefined;
@@ -47,34 +68,36 @@ function toPrice(value: bigint | undefined): PriceInt | undefined {
 function updateMid(state: BookState): void {
   const bid = toRawPrice(state.bestBid);
   const ask = toRawPrice(state.bestAsk);
+  let mid: bigint | undefined;
   if (bid !== undefined && ask !== undefined) {
-    setBookPrice(state, 'mid', toPrice((bid + ask) / 2n));
+    mid = (bid + ask) / 2n;
+  } else {
+    const lastTrade = toRawPrice(state.lastTrade);
+    if (lastTrade !== undefined) {
+      mid = lastTrade;
+    }
+  }
+  if (mid === undefined) {
+    setBookPrice(state, 'mid', undefined);
+    state.marketReady = false;
     return;
   }
-  if (bid !== undefined) {
-    setBookPrice(state, 'mid', toPrice(bid));
-    return;
-  }
-  if (ask !== undefined) {
-    setBookPrice(state, 'mid', toPrice(ask));
-    return;
-  }
-  if (state.lastTrade !== undefined) {
-    setBookPrice(state, 'mid', state.lastTrade);
-    return;
-  }
-  setBookPrice(state, 'mid', undefined);
+  setBookPrice(state, 'mid', toPrice(mid));
+  state.marketReady = true;
 }
 
 function applyDepthLevels(
   levels: Map<bigint, bigint>,
   updates: DepthEvent['payload']['bids'],
   priceSelector: (level: DepthEvent['payload']['bids'][number]) => PriceInt,
-  qtySelector: (level: DepthEvent['payload']['bids'][number]) => bigint,
+  qtySelector: (level: DepthEvent['payload']['bids'][number]) => QtyInt,
 ): void {
   for (const level of updates) {
-    const price = priceSelector(level) as unknown as bigint;
+    const price = normalizeInt(priceSelector(level));
     const qty = toRawQty(qtySelector(level));
+    if (price === undefined || qty === undefined) {
+      continue;
+    }
     if (qty <= 0n) {
       levels.delete(price);
     } else {
@@ -103,13 +126,13 @@ function applyDepth(state: BookState, event: DepthEvent): void {
     state.bids,
     event.payload.bids,
     (level) => level.price,
-    (level) => level.qty as unknown as bigint,
+    (level) => level.qty,
   );
   applyDepthLevels(
     state.asks,
     event.payload.asks,
     (level) => level.price,
-    (level) => level.qty as unknown as bigint,
+    (level) => level.qty,
   );
   const bestBid = computeBest(state.bids, (current, price) =>
     current === undefined || price > current ? price : current,
@@ -123,16 +146,16 @@ function applyDepth(state: BookState, event: DepthEvent): void {
 }
 
 function applyTrade(state: BookState, event: TradeEvent): void {
-  state.lastTrade = event.payload.price;
-  if (!state.mid) {
-    state.mid = event.payload.price;
-  } else if (state.bestBid === undefined && state.bestAsk === undefined) {
-    state.mid = event.payload.price;
+  const price = toRawPrice(event.payload.price);
+  if (price === undefined) {
+    return;
   }
+  state.lastTrade = toPrice(price);
 }
 
 export function createBookState(): BookState {
   return {
+    marketReady: false,
     bids: new Map<bigint, bigint>(),
     asks: new Map<bigint, bigint>(),
   } satisfies BookState;

--- a/examples/09-bot-skeleton/lib/fixed.ts
+++ b/examples/09-bot-skeleton/lib/fixed.ts
@@ -1,0 +1,32 @@
+const INT_RE = /^\d+$/;
+
+export const isIntString = (value?: string | null): value is string => {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 && INT_RE.test(trimmed);
+};
+
+export function toBigIntOr(
+  source: string | undefined | null,
+  fallback: bigint,
+): bigint {
+  if (!isIntString(source)) {
+    return fallback;
+  }
+  return BigInt(source.trim());
+}
+
+export function mulDivInt(a: string, b: string, c: string): string {
+  if (!isIntString(a) || !isIntString(b) || !isIntString(c)) {
+    throw new Error('mulDivInt expects int strings');
+  }
+  const A = BigInt(a.trim());
+  const B = BigInt(b.trim());
+  const C = BigInt(c.trim());
+  if (C === 0n) {
+    throw new Error('mulDivInt expects non-zero denominator');
+  }
+  return ((A * B) / C).toString(10);
+}

--- a/examples/09-bot-skeleton/lib/rng.ts
+++ b/examples/09-bot-skeleton/lib/rng.ts
@@ -1,0 +1,17 @@
+export type Prng = () => number;
+
+function normalizeSeed(seed: number): number {
+  const normalized = seed >>> 0;
+  return normalized === 0 ? 0x9e3779b9 : normalized;
+}
+
+export function makeXorShift32(seed: number): Prng {
+  let state = normalizeSeed(Number.isFinite(seed) ? seed : 0);
+  return () => {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    state >>>= 0;
+    return state / 0x100000000;
+  };
+}

--- a/examples/09-bot-skeleton/smoke.ts
+++ b/examples/09-bot-skeleton/smoke.ts
@@ -33,8 +33,8 @@ function main(): void {
   const stderr = result.stderr ?? '';
 
   const printSnippet = (): void => {
-    const stdoutSnippet = stdout.slice(0, 600) || '<empty>';
-    const stderrSnippet = stderr.slice(0, 600) || '<empty>';
+    const stdoutSnippet = stdout.slice(0, 500) || '<empty>';
+    const stderrSnippet = stderr.slice(0, 500) || '<empty>';
     console.error('[examples/09-bot-skeleton] stdout snippet:', stdoutSnippet);
     console.error('[examples/09-bot-skeleton] stderr snippet:', stderrSnippet);
   };


### PR DESCRIPTION
## Summary
- introduce a deterministic xor-shift PRNG and integer-string helpers to keep bot math reproducible and safe
- gate actions on market readiness, debounce by sim time, enforce risk checks, support replace-as-cancel+place, and close/clean NDJSON logs
- document environment knobs and NDJSON usage while tightening smoke diagnostics

## Testing
- pnpm -w examples:build
- TF_TRADES_FILES=examples/_smoke/mini-trades.jsonl TF_DEPTH_FILES=examples/_smoke/mini-depth.jsonl TF_CLOCK=logical TF_MAX_EVENTS=1500 TF_QTY="0.001" TF_SEED=42 node dist-examples/09-bot-skeleton/run.js
- node examples/09-bot-skeleton/smoke.ts

------
https://chatgpt.com/codex/tasks/task_e_68cc230d9a548320b74bbb3dfcd0688a