### PR TITLE
ci: add reusable workflow for node/schema matrix

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -1,0 +1,73 @@
+name: Reusable CI (build, lint & test)
+
+on:
+  workflow_call:
+    inputs:
+      node_versions:
+        description: 'Node versions (JSON array)'
+        required: false
+        type: string
+        default: '["18.x","20.x"]'
+      schemas:
+        description: 'Schema matrix (JSON array)'
+        required: false
+        type: string
+        default: '["v1"]'
+      allow_v2_failure:
+        description: 'Treat SCHEMA=v2 as non-blocking'
+        required: false
+        type: boolean
+        default: true
+      working_directory:
+        description: 'Working directory for install/build/test'
+        required: false
+        type: string
+        default: '.'
+
+jobs:
+  build-and-test:
+    name: Node ${{ matrix.node }} / Schema ${{ matrix.schema }}
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ inputs.allow_v2_failure && matrix.schema == 'v2' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ${{ fromJson(inputs.node_versions) }}
+        schema: ${{ fromJson(inputs.schemas) }}
+    env:
+      SCHEMA: ${{ matrix.schema }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'pnpm'
+          cache-dependency-path: ${{ format('{0}/pnpm-lock.yaml', inputs.working_directory) }}
+
+      - name: Install dependencies
+        working-directory: ${{ inputs.working_directory }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        working-directory: ${{ inputs.working_directory }}
+        run: pnpm run build
+
+      - name: Lint
+        working-directory: ${{ inputs.working_directory }}
+        run: pnpm run lint
+
+      - name: Test
+        working-directory: ${{ inputs.working_directory }}
+        run: pnpm run test -- --coverage
+
+      - name: Soft-fail note for schema v2
+        if: ${{ inputs.allow_v2_failure && matrix.schema == 'v2' }}
+        run: echo 'SCHEMA=v2 run is marked as non-blocking (allowed failure).'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,23 +1,14 @@
 name: CI
 
 on:
-  push:
   pull_request:
+  push:
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [22]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node }}
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm build
-      - run: pnpm lint
-      - run: pnpm test -- --coverage
+  main:
+    uses: ./.github/workflows/ci-reusable.yml
+    with:
+      node_versions: '["18.x","20.x"]'
+      schemas: '["v1","v2"]'
+      allow_v2_failure: true
+      working_directory: '.'

--- a/README.md
+++ b/README.md
@@ -13,6 +13,21 @@ pnpm --filter @tradeforge/cli dev
 pnpm --filter @tradeforge/cli dev -- --version
 ```
 
+## Reusable CI workflow
+
+Проект использует переиспользуемый workflow `.github/workflows/ci-reusable.yml`. Вы можете настраивать матрицу через inputs в `.github/workflows/ci.yml`:
+
+```yaml
+jobs:
+  main:
+    uses: ./.github/workflows/ci-reusable.yml
+    with:
+      node_versions: '["18.x","20.x"]'
+      schemas: '["v1","v2"]'
+      allow_v2_failure: true
+      working_directory: '.'
+```
+
 ## REST service
 
 HTTP адаптер доступен в пакете `@tradeforge/svc`:


### PR DESCRIPTION
## Summary
- add a reusable workflow that runs install, build, lint and test across node/schema matrices
- call the reusable workflow from the default CI configuration with both schema versions allowed to fail softly
- document how to consume the reusable workflow in README

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cd189aaf388320a98a41c95de3d42d