### PR TITLE
chore(ci): pnpm-store cache + permissions & concurrency

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -62,6 +62,14 @@ jobs:
             echo "package.json not found at $PACKAGE_JSON; skipping pnpm activation."
           fi
 
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ~/.pnpm-store
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles(format('{0}/pnpm-lock.yaml', inputs.working_directory)) }}
+          restore-keys: |
+            pnpm-store-${{ runner.os }}-
+
       - name: Install dependencies
         working-directory: ${{ inputs.working_directory }}
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,13 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     # Один job, входы зависят от типа события


### PR DESCRIPTION
## Summary
- cache the pnpm store in the reusable CI workflow to speed up installs
- harden the consumer CI workflow with read-only contents permission and concurrency cancellation

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cd40e79c8c8320a47b1ff912dfb80c