### PR TITLE
feat: add binance loader package

### DIFF
--- a/examples/_data/binance-loader.ts
+++ b/examples/_data/binance-loader.ts
@@ -1,0 +1,35 @@
+import {
+  createTradeStream,
+  createDepthStream,
+  syncBinanceDataset,
+} from '@tradeforge/loader-binance';
+import type { SymbolId } from '@tradeforge/core';
+
+const SYMBOL = 'BTCUSDT' as SymbolId;
+const DATE = '2021-05-01';
+
+async function main(): Promise<void> {
+  await syncBinanceDataset({ symbol: SYMBOL, date: DATE });
+
+  const tradeStream = createTradeStream({ symbol: SYMBOL, date: DATE });
+  const depthStream = createDepthStream({ symbol: SYMBOL, date: DATE });
+
+  let tradesShown = 0;
+  console.log('First trades:');
+  for await (const trade of tradeStream) {
+    console.log(trade);
+    if (++tradesShown >= 5) break;
+  }
+
+  let depthShown = 0;
+  console.log('First depth diffs:');
+  for await (const diff of depthStream) {
+    console.log(diff);
+    if (++depthShown >= 5) break;
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,20 +1,26 @@
-import { resolve } from 'path';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT_DIR = fileURLToPath(new URL('.', import.meta.url));
 
 export default {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
+  rootDir: ROOT_DIR,
   extensionsToTreatAsEsm: ['.ts'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
     '^@tradeforge/core$': '<rootDir>/packages/core/src/index.ts',
     '^@tradeforge/io-binance$': '<rootDir>/packages/io-binance/src/index.ts',
+    '^@tradeforge/loader-binance$': '<rootDir>/packages/loader-binance/src/index.ts',
+    '^@tradeforge/schemas/v1/(.*)$': '<rootDir>/packages/schemas/src/v1/$1.schema.json',
     '^@tradeforge/schemas$': '<rootDir>/packages/schemas/src/index.ts',
     '^@tradeforge/validation$': '<rootDir>/packages/validation/src/index.ts',
   },
   transform: {
     '^.+\\.ts$': [
       'ts-jest',
-      { useESM: true, tsconfig: resolve('tsconfig.jest.json') },
+      { useESM: true, tsconfig: join(ROOT_DIR, 'tsconfig.jest.json') },
     ],
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "examples:ex01:build": "tsc -p tsconfig.examples.json --incremental",
     "examples:ex01:smoke": "node examples/01-basic-replay/smoke.ts",
     "examples:ex09": "node dist-examples/09-bot-skeleton/run.js",
-    "examples:ex09:smoke": "node examples/09-bot-skeleton/smoke.ts"
+    "examples:ex09:smoke": "node examples/09-bot-skeleton/smoke.ts",
+    "loader:binance": "pnpm --filter @tradeforge/loader-binance run cli --"
   },
   "devDependencies": {
     "@types/jest": "^29.5.11",

--- a/packages/loader-binance/README.md
+++ b/packages/loader-binance/README.md
@@ -1,0 +1,34 @@
+# @tradeforge/loader-binance
+
+Загрузчик архивов Binance Data Portal с локальным кэшем.
+
+## Возможности
+
+- CLI-команда `pnpm loader:binance sync`.
+- Кэширование в `datasets/binance/<symbol>/<date>/`.
+- Потоки сделок и диффов глубины через `createTradeStream` и `createDepthStream`.
+
+## Использование
+
+```bash
+pnpm loader:binance sync --symbol BTCUSDT --date 2021-05-01
+```
+
+```ts
+import {
+  createTradeStream,
+  createDepthStream,
+  syncBinanceDataset,
+} from '@tradeforge/loader-binance';
+
+await syncBinanceDataset({ symbol: 'BTCUSDT', date: '2021-05-01' });
+
+const trades = createTradeStream({ symbol: 'BTCUSDT', date: '2021-05-01' });
+const depth = createDepthStream({ symbol: 'BTCUSDT', date: '2021-05-01' });
+```
+
+## Тесты
+
+```bash
+pnpm --filter @tradeforge/loader-binance run test
+```

--- a/packages/loader-binance/package.json
+++ b/packages/loader-binance/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@tradeforge/loader-binance",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --dts --format esm --out-dir dist",
+    "clean": "rimraf dist",
+    "format": "prettier -w .",
+    "lint": "eslint . --ext .ts",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --config ../../jest.config.mjs --testPathPattern packages/loader-binance/tests",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "cli": "tsx src/cli.ts"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@tradeforge/core": "workspace:^",
+    "@tradeforge/io-binance": "workspace:^",
+    "commander": "^13.1.0",
+    "unzipper": "^0.12.3"
+  },
+  "devDependencies": {
+    "nock": "^13.5.2"
+  }
+}

--- a/packages/loader-binance/src/cli.ts
+++ b/packages/loader-binance/src/cli.ts
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+import { Command } from 'commander';
+import { syncBinanceDataset } from './sync.js';
+import { DEFAULT_ROOT_DIR } from './constants.js';
+import { createTradeStream, createDepthStream } from './streams.js';
+import { fileURLToPath } from 'node:url';
+import { basename } from 'node:path';
+
+async function collectPreview<T>(
+  iter: AsyncIterable<T>,
+  limit: number,
+): Promise<T[]> {
+  const out: T[] = [];
+  for await (const item of iter) {
+    out.push(item);
+    if (out.length >= limit) break;
+  }
+  return out;
+}
+
+export function createCli(): Command {
+  const program = new Command();
+  program
+    .name('loader:binance')
+    .description('Binance Data Portal loader')
+    .configureHelp({ sortSubcommands: true })
+    .configureOutput({
+      outputError(str, write) {
+        write(str);
+      },
+    });
+
+  program
+    .command('sync')
+    .description('Download and cache Binance archives for given date')
+    .requiredOption('--symbol <symbol>', 'Trading pair', 'BTCUSDT')
+    .requiredOption('--date <yyyy-mm-dd>', 'Target date (UTC)')
+    .option(
+      '--root <path>',
+      `Root dataset directory (default: ${DEFAULT_ROOT_DIR})`,
+    )
+    .option('--base-url <url>', 'Override base URL of Binance Data Portal')
+    .option('--force', 'Force re-download even if cache is present', false)
+    .option('--preview', 'Print first entries after sync', false)
+    .action(async (opts) => {
+      const report = await syncBinanceDataset({
+        symbol: opts.symbol,
+        date: opts.date,
+        rootDir: opts.root,
+        baseUrl: opts.baseUrl,
+        force: Boolean(opts.force),
+      });
+      for (const item of report.items) {
+        const status = item.status === 'downloaded' ? 'downloaded' : 'skipped';
+        const size = item.bytes
+          ? ` (${Math.round((item.bytes / 1024) * 10) / 10} KiB)`
+          : '';
+        console.log(`✔ ${item.kind} ${status}${size}`);
+      }
+      if (opts.preview) {
+        const trades = createTradeStream({
+          symbol: report.symbol,
+          date: report.date,
+          rootDir: opts.root,
+        });
+        const depth = createDepthStream({
+          symbol: report.symbol,
+          date: report.date,
+          rootDir: opts.root,
+        });
+        const [tradePreview, depthPreview] = await Promise.all([
+          collectPreview(trades, 3),
+          collectPreview(depth, 3),
+        ]);
+        console.log(`Trades preview (${tradePreview.length}):`);
+        for (const entry of tradePreview) {
+          console.log(JSON.stringify(entry));
+        }
+        console.log(`Depth preview (${depthPreview.length}):`);
+        for (const entry of depthPreview) {
+          console.log(JSON.stringify(entry));
+        }
+      }
+    });
+
+  return program;
+}
+
+async function main(argv: string[]): Promise<void> {
+  const program = createCli();
+  await program.parseAsync(argv);
+}
+
+const isMain = (() => {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  const modulePath = fileURLToPath(import.meta.url);
+  return basename(entry) === basename(modulePath);
+})();
+
+if (isMain) {
+  main(process.argv).catch((err) => {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(message);
+    process.exitCode = 1;
+  });
+}

--- a/packages/loader-binance/src/constants.ts
+++ b/packages/loader-binance/src/constants.ts
@@ -1,0 +1,20 @@
+import { resolve } from 'node:path';
+
+export const DEFAULT_BASE_URL = 'https://data.binance.vision';
+export const DEFAULT_ROOT_DIR = resolve('datasets', 'binance');
+export const SUPPORTED_SYMBOLS = new Set(['BTCUSDT']);
+
+export const TRADE_ARCHIVE_PATH =
+  'data/futures/um/daily/trades/{symbol}/{symbol}-trades-{date}.json.gz';
+export const DEPTH_ARCHIVE_PATH =
+  'data/futures/um/daily/diffBookDepth/{symbol}/{symbol}-diffBookDepth-{date}.json.gz';
+
+export type ArchiveKind = 'trades' | 'depth';
+
+export const ARCHIVE_DEFINITIONS: Record<
+  ArchiveKind,
+  { template: string; filename: string }
+> = {
+  trades: { template: TRADE_ARCHIVE_PATH, filename: 'trades.json.gz' },
+  depth: { template: DEPTH_ARCHIVE_PATH, filename: 'depth.json.gz' },
+};

--- a/packages/loader-binance/src/index.ts
+++ b/packages/loader-binance/src/index.ts
@@ -1,0 +1,11 @@
+export type {
+  SyncOptions,
+  SyncReport,
+  SyncReportItem,
+  TradeStreamOptions,
+  DepthStreamOptions,
+  TradeStream,
+  DepthStream,
+} from './types.js';
+export { syncBinanceDataset } from './sync.js';
+export { createTradeStream, createDepthStream } from './streams.js';

--- a/packages/loader-binance/src/parse/depth.ts
+++ b/packages/loader-binance/src/parse/depth.ts
@@ -1,0 +1,75 @@
+import type {
+  DepthDiff,
+  SymbolId,
+  SymbolScaleMap,
+  TimestampMs,
+} from '@tradeforge/core';
+import { getScaleFor, toPriceInt, toQtyInt } from '@tradeforge/core';
+import type { DepthStreamOptions } from '../types.js';
+import { readJsonLinesGzip } from './jsonl.js';
+
+interface RawDepthRecord {
+  [key: string]: unknown;
+}
+
+type LevelInput = [unknown, unknown] | { price?: unknown; qty?: unknown };
+
+function toTimestamp(raw: RawDepthRecord): TimestampMs {
+  const source =
+    raw.E ??
+    raw.eventTime ??
+    raw.timestamp ??
+    raw.ts ??
+    raw.time ??
+    raw.T ??
+    raw.date;
+  const value = Number(source);
+  if (!Number.isFinite(value)) {
+    throw new Error(`Invalid depth timestamp: ${JSON.stringify(raw)}`);
+  }
+  return value as TimestampMs;
+}
+
+function toLevels(input: unknown): LevelInput[] {
+  if (!Array.isArray(input)) return [];
+  return input as LevelInput[];
+}
+
+function buildLevel(
+  level: LevelInput,
+  priceScale: number,
+  qtyScale: number,
+): { price: number; qty: number } {
+  const priceSource = Array.isArray(level) ? level[0] : level.price;
+  const qtySource = Array.isArray(level) ? level[1] : level.qty;
+  const price = toPriceInt(String(priceSource ?? '0'), priceScale);
+  const qty = toQtyInt(String(qtySource ?? '0'), qtyScale);
+  return { price, qty };
+}
+
+function mapDepthRecord(
+  raw: RawDepthRecord,
+  symbol: SymbolId,
+  scaleOverride?: SymbolScaleMap,
+): DepthDiff {
+  const ts = toTimestamp(raw);
+  const scale = getScaleFor(symbol, scaleOverride);
+  const mapLevel = (level: LevelInput) =>
+    buildLevel(level, scale.priceScale, scale.qtyScale);
+  const bids = toLevels(raw.b ?? raw.bids ?? raw.Bids).map(mapLevel);
+  const asks = toLevels(raw.a ?? raw.asks ?? raw.Asks).map(mapLevel);
+  return { ts, symbol, bids, asks };
+}
+
+export async function* parseDepthFile(
+  path: string,
+  opts: DepthStreamOptions,
+): AsyncIterable<DepthDiff> {
+  for await (const raw of readJsonLinesGzip(path)) {
+    yield mapDepthRecord(
+      raw as RawDepthRecord,
+      opts.symbol,
+      opts.scaleOverride,
+    );
+  }
+}

--- a/packages/loader-binance/src/parse/jsonl.ts
+++ b/packages/loader-binance/src/parse/jsonl.ts
@@ -1,0 +1,30 @@
+import { createReadStream } from 'node:fs';
+import { Readable } from 'node:stream';
+import { createGunzip } from 'node:zlib';
+
+async function* lineSplitter(stream: Readable): AsyncIterable<string> {
+  let buffer = '';
+  for await (const chunk of stream) {
+    buffer += chunk.toString('utf8');
+    let idx = buffer.indexOf('\n');
+    while (idx >= 0) {
+      const line = buffer.slice(0, idx).replace(/\r$/, '');
+      buffer = buffer.slice(idx + 1);
+      if (line.length > 0) {
+        yield line;
+      }
+      idx = buffer.indexOf('\n');
+    }
+  }
+  const rest = buffer.trim();
+  if (rest.length > 0) {
+    yield rest;
+  }
+}
+
+export async function* readJsonLinesGzip(path: string): AsyncIterable<unknown> {
+  const stream = createReadStream(path).pipe(createGunzip());
+  for await (const line of lineSplitter(stream as unknown as Readable)) {
+    yield JSON.parse(line) as unknown;
+  }
+}

--- a/packages/loader-binance/src/parse/trades.ts
+++ b/packages/loader-binance/src/parse/trades.ts
@@ -1,0 +1,115 @@
+import type {
+  Trade,
+  SymbolId,
+  SymbolScaleMap,
+  TimestampMs,
+  Side,
+} from '@tradeforge/core';
+import { getScaleFor, toPriceInt, toQtyInt } from '@tradeforge/core';
+import type { TradeStreamOptions } from '../types.js';
+import { readJsonLinesGzip } from './jsonl.js';
+
+interface RawTradeRecord {
+  [key: string]: unknown;
+}
+
+function extractTime(raw: RawTradeRecord): unknown {
+  return (
+    raw.time ??
+    raw.timestamp ??
+    raw.T ??
+    raw.ts ??
+    raw.tradeTime ??
+    raw.eventTime ??
+    raw.date
+  );
+}
+
+function extractPrice(raw: RawTradeRecord): unknown {
+  return raw.price ?? raw.p ?? raw.P ?? raw.lastPrice;
+}
+
+function extractQty(raw: RawTradeRecord): unknown {
+  return raw.qty ?? raw.q ?? raw.Q ?? raw.quantity ?? raw.baseQty;
+}
+
+function extractId(raw: RawTradeRecord): unknown {
+  return raw.id ?? raw.tradeId ?? raw.t ?? raw.uid ?? raw.eventId;
+}
+
+function extractSide(raw: RawTradeRecord): string | undefined {
+  const side = raw.side ?? raw.S ?? raw.s;
+  if (typeof side === 'string') {
+    return side.toUpperCase();
+  }
+  const isBuyerMaker = raw.isBuyerMaker ?? raw.m ?? raw.M;
+  if (typeof isBuyerMaker === 'boolean') {
+    return isBuyerMaker ? 'SELL' : 'BUY';
+  }
+  if (typeof isBuyerMaker === 'string') {
+    const lowered = isBuyerMaker.toLowerCase();
+    if (lowered === 'true' || lowered === '1') return 'SELL';
+    if (lowered === 'false' || lowered === '0') return 'BUY';
+  }
+  return undefined;
+}
+
+function normalizeMappedTrade(
+  mapped: Record<string, unknown>,
+  symbol: SymbolId,
+  scaleOverride?: SymbolScaleMap,
+): Trade {
+  const scale = getScaleFor(symbol, scaleOverride);
+  const tsValue = Number(mapped.time);
+  if (!Number.isFinite(tsValue)) {
+    throw new Error(`Trade timestamp is invalid: ${mapped.time}`);
+  }
+  const ts = tsValue as TimestampMs;
+  const price = toPriceInt(String(mapped.price), scale.priceScale);
+  const qty = toQtyInt(String(mapped.qty), scale.qtyScale);
+  const trade: Trade = {
+    ts,
+    symbol,
+    price,
+    qty,
+  };
+  const side = mapped.side;
+  if (typeof side === 'string') {
+    trade.side = side.toUpperCase() as Side;
+    trade.aggressor = trade.side;
+  }
+  const id = mapped.id;
+  if (id !== undefined) {
+    trade.id = String(id);
+  }
+  return trade;
+}
+
+function mapTradeRecord(raw: RawTradeRecord): Record<string, unknown> {
+  const time = extractTime(raw);
+  const price = extractPrice(raw);
+  const qty = extractQty(raw);
+  if (time === undefined || price === undefined || qty === undefined) {
+    throw new Error(`Invalid trade record: ${JSON.stringify(raw)}`);
+  }
+  const payload: Record<string, unknown> = {
+    time,
+    price,
+    qty,
+  };
+  const id = extractId(raw);
+  if (id !== undefined) payload.id = id;
+  const side = extractSide(raw);
+  if (side) payload.side = side;
+  return payload;
+}
+
+export async function* parseTradesFile(
+  path: string,
+  opts: TradeStreamOptions,
+): AsyncIterable<Trade> {
+  for await (const raw of readJsonLinesGzip(path)) {
+    const mapped = mapTradeRecord(raw as RawTradeRecord);
+    yield normalizeMappedTrade(mapped, opts.symbol, opts.scaleOverride);
+  }
+}

--- a/packages/loader-binance/src/paths.ts
+++ b/packages/loader-binance/src/paths.ts
@@ -1,0 +1,23 @@
+import { join } from 'node:path';
+import { resolveRoot } from './utils/fs.js';
+import { ARCHIVE_DEFINITIONS } from './constants.js';
+import type { ArchiveKind } from './constants.js';
+
+export function resolveDatasetDir(
+  symbol: string,
+  date: string,
+  rootDir?: string,
+): string {
+  return join(resolveRoot(rootDir), symbol, date);
+}
+
+export function resolveDatasetFile(
+  kind: ArchiveKind,
+  symbol: string,
+  date: string,
+  rootDir?: string,
+): string {
+  const dir = resolveDatasetDir(symbol, date, rootDir);
+  const def = ARCHIVE_DEFINITIONS[kind];
+  return join(dir, def.filename);
+}

--- a/packages/loader-binance/src/streams.ts
+++ b/packages/loader-binance/src/streams.ts
@@ -1,0 +1,29 @@
+import { resolveDatasetFile } from './paths.js';
+import type {
+  DepthStream,
+  DepthStreamOptions,
+  TradeStream,
+  TradeStreamOptions,
+} from './types.js';
+import { parseTradesFile } from './parse/trades.js';
+import { parseDepthFile } from './parse/depth.js';
+
+export function createTradeStream(options: TradeStreamOptions): TradeStream {
+  const file = resolveDatasetFile(
+    'trades',
+    options.symbol,
+    options.date,
+    options.rootDir,
+  );
+  return parseTradesFile(file, options);
+}
+
+export function createDepthStream(options: DepthStreamOptions): DepthStream {
+  const file = resolveDatasetFile(
+    'depth',
+    options.symbol,
+    options.date,
+    options.rootDir,
+  );
+  return parseDepthFile(file, options);
+}

--- a/packages/loader-binance/src/sync.ts
+++ b/packages/loader-binance/src/sync.ts
@@ -1,0 +1,57 @@
+import { unlink } from 'node:fs/promises';
+import { ARCHIVE_DEFINITIONS, type ArchiveKind } from './constants.js';
+import { resolveDatasetDir, resolveDatasetFile } from './paths.js';
+import type { SyncOptions, SyncReport, SyncReportItem } from './types.js';
+import { assertDate, assertSymbol } from './utils/validators.js';
+import { ensureDir, pathExists, fileSize } from './utils/fs.js';
+import { buildArchiveUrl } from './utils/template.js';
+import { downloadToTempFile } from './utils/http.js';
+import { storeArchive } from './utils/archive.js';
+
+async function handleArchive(
+  kind: ArchiveKind,
+  symbol: string,
+  date: string,
+  rootDir: string | undefined,
+  baseUrl: string | undefined,
+  force: boolean,
+  fetchImpl?: typeof fetch,
+): Promise<SyncReportItem> {
+  const targetPath = resolveDatasetFile(kind, symbol, date, rootDir);
+  if (!force && (await pathExists(targetPath))) {
+    return { kind, status: 'skipped', path: targetPath };
+  }
+  const url = buildArchiveUrl(kind, symbol, date, baseUrl);
+  const { path: tempPath, bytes } = await downloadToTempFile(url, fetchImpl);
+  try {
+    await storeArchive(tempPath, targetPath, kind);
+  } catch (err) {
+    await unlink(tempPath).catch(() => undefined);
+    throw err;
+  }
+  const size = bytes ?? (await fileSize(targetPath));
+  return { kind, status: 'downloaded', bytes: size, path: targetPath };
+}
+
+export async function syncBinanceDataset(
+  options: SyncOptions,
+): Promise<SyncReport> {
+  const symbol = assertSymbol(options.symbol);
+  const date = assertDate(options.date);
+  const datasetDir = resolveDatasetDir(symbol, date, options.rootDir);
+  await ensureDir(datasetDir);
+  const reportItems: SyncReportItem[] = [];
+  for (const kind of Object.keys(ARCHIVE_DEFINITIONS) as ArchiveKind[]) {
+    const item = await handleArchive(
+      kind,
+      symbol,
+      date,
+      options.rootDir,
+      options.baseUrl,
+      options.force ?? false,
+      options.fetchImpl,
+    );
+    reportItems.push(item);
+  }
+  return { symbol, date, datasetDir, items: reportItems };
+}

--- a/packages/loader-binance/src/types.ts
+++ b/packages/loader-binance/src/types.ts
@@ -1,0 +1,44 @@
+import type {
+  SymbolId,
+  SymbolScaleMap,
+  DepthDiff,
+  Trade,
+} from '@tradeforge/core';
+import type { ArchiveKind } from './constants.js';
+
+export interface SyncOptions {
+  symbol: SymbolId;
+  date: string;
+  rootDir?: string;
+  baseUrl?: string;
+  force?: boolean;
+  fetchImpl?: typeof fetch;
+}
+
+export interface SyncReportItem {
+  kind: ArchiveKind;
+  status: 'downloaded' | 'skipped';
+  bytes?: number;
+  path: string;
+}
+
+export interface SyncReport {
+  symbol: SymbolId;
+  date: string;
+  datasetDir: string;
+  items: SyncReportItem[];
+}
+
+export interface BaseStreamOptions {
+  symbol: SymbolId;
+  date: string;
+  rootDir?: string;
+  scaleOverride?: SymbolScaleMap;
+}
+
+export interface TradeStreamOptions extends BaseStreamOptions {}
+
+export interface DepthStreamOptions extends BaseStreamOptions {}
+
+export type TradeStream = AsyncIterable<Trade>;
+export type DepthStream = AsyncIterable<DepthDiff>;

--- a/packages/loader-binance/src/utils/archive.ts
+++ b/packages/loader-binance/src/utils/archive.ts
@@ -1,0 +1,55 @@
+import { createReadStream, createWriteStream } from 'node:fs';
+import { unlink } from 'node:fs/promises';
+import { basename, dirname, extname } from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { createGzip } from 'node:zlib';
+import unzipper from 'unzipper';
+import { ensureDir } from './fs.js';
+
+export async function storeArchive(
+  sourcePath: string,
+  targetPath: string,
+  kind: 'trades' | 'depth',
+): Promise<void> {
+  const ext = extname(sourcePath).toLowerCase();
+  if (ext === '.gz' || sourcePath.toLowerCase().endsWith('.json.gz')) {
+    await ensureDir(dirname(targetPath));
+    await pipeline(createReadStream(sourcePath), createWriteStream(targetPath));
+    await unlink(sourcePath);
+    return;
+  }
+  if (ext === '.zip') {
+    await extractZipEntry(sourcePath, targetPath, kind);
+    await unlink(sourcePath);
+    return;
+  }
+  throw new Error(`Unsupported archive format for ${basename(sourcePath)}`);
+}
+
+async function extractZipEntry(
+  sourcePath: string,
+  targetPath: string,
+  kind: 'trades' | 'depth',
+): Promise<void> {
+  const directory = await unzipper.Open.file(sourcePath);
+  const normalizedKind = kind === 'trades' ? 'trades' : 'depth';
+  const expectedName = `${normalizedKind}.json.gz`;
+  const expectedJson = `${normalizedKind}.json`;
+  const entry = directory.files.find((file) => {
+    const lower = file.path.toLowerCase();
+    return lower.endsWith(expectedName) || lower.endsWith(expectedJson);
+  });
+  if (!entry) {
+    const names = directory.files.map((f) => f.path).join(', ');
+    throw new Error(
+      `Archive ${basename(sourcePath)} does not contain ${expectedName}; entries: ${names}`,
+    );
+  }
+  await ensureDir(dirname(targetPath));
+  const stream = entry.stream();
+  if (entry.path.toLowerCase().endsWith('.json')) {
+    await pipeline(stream, createGzip(), createWriteStream(targetPath));
+  } else {
+    await pipeline(stream, createWriteStream(targetPath));
+  }
+}

--- a/packages/loader-binance/src/utils/fs.ts
+++ b/packages/loader-binance/src/utils/fs.ts
@@ -1,0 +1,31 @@
+import { mkdir, rename, access, stat } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { DEFAULT_ROOT_DIR } from '../constants.js';
+
+export async function ensureDir(path: string): Promise<void> {
+  await mkdir(path, { recursive: true });
+}
+
+export async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function moveFile(src: string, dest: string): Promise<void> {
+  await ensureDir(dirname(dest));
+  await rename(src, dest);
+}
+
+export function resolveRoot(rootDir?: string): string {
+  return resolve(rootDir ?? DEFAULT_ROOT_DIR);
+}
+
+export async function fileSize(path: string): Promise<number> {
+  const info = await stat(path);
+  return info.size;
+}

--- a/packages/loader-binance/src/utils/http.ts
+++ b/packages/loader-binance/src/utils/http.ts
@@ -1,0 +1,73 @@
+import { createWriteStream } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { pipeline } from 'node:stream/promises';
+import { Readable } from 'node:stream';
+import { request as httpRequest } from 'node:http';
+import { request as httpsRequest } from 'node:https';
+import type { IncomingMessage } from 'node:http';
+import { URL } from 'node:url';
+
+export interface DownloadResult {
+  path: string;
+  bytes: number;
+}
+
+function isNodeReadable(value: unknown): value is NodeJS.ReadableStream {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as NodeJS.ReadableStream).pipe === 'function'
+  );
+}
+
+async function requestViaNode(url: URL): Promise<IncomingMessage> {
+  const requester = url.protocol === 'http:' ? httpRequest : httpsRequest;
+  return await new Promise<IncomingMessage>((resolve, reject) => {
+    const req = requester(url, (res) => {
+      const statusCode = res.statusCode ?? 0;
+      if (statusCode >= 400 || statusCode === 0) {
+        const statusText = res.statusMessage ?? 'Unknown error';
+        res.resume();
+        reject(
+          new Error(
+            `Failed to download ${url.toString()}: ${statusCode} ${statusText}`,
+          ),
+        );
+        return;
+      }
+      resolve(res);
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+export async function downloadToTempFile(
+  url: string,
+  fetchImpl?: typeof fetch,
+): Promise<DownloadResult> {
+  const urlObject = new URL(url);
+  const extMatch = url.match(/\.[a-zA-Z0-9]+(?:\.gz)?$/);
+  const ext = extMatch ? extMatch[0] : '';
+  const tmpPath = join(tmpdir(), `binance-loader-${randomUUID()}${ext}`);
+  const fileStream = createWriteStream(tmpPath);
+  if (fetchImpl) {
+    const response = await fetchImpl(url);
+    if (!response.ok || !response.body) {
+      throw new Error(
+        `Failed to download ${url}: ${response.status} ${response.statusText}`,
+      );
+    }
+    const body = response.body;
+    const nodeStream = isNodeReadable(body)
+      ? body
+      : Readable.fromWeb(body as globalThis.ReadableStream<Uint8Array>);
+    await pipeline(nodeStream, fileStream);
+  } else {
+    const response = await requestViaNode(urlObject);
+    await pipeline(response, fileStream);
+  }
+  return { path: tmpPath, bytes: fileStream.bytesWritten };
+}

--- a/packages/loader-binance/src/utils/template.ts
+++ b/packages/loader-binance/src/utils/template.ts
@@ -1,0 +1,16 @@
+import { ARCHIVE_DEFINITIONS, DEFAULT_BASE_URL } from '../constants.js';
+import type { ArchiveKind } from '../constants.js';
+
+export function buildArchiveUrl(
+  kind: ArchiveKind,
+  symbol: string,
+  date: string,
+  baseUrl: string = DEFAULT_BASE_URL,
+): string {
+  const def = ARCHIVE_DEFINITIONS[kind];
+  const path = def.template
+    .replaceAll('{symbol}', symbol)
+    .replaceAll('{date}', date);
+  const base = (baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, '');
+  return `${base}/${path}`;
+}

--- a/packages/loader-binance/src/utils/validators.ts
+++ b/packages/loader-binance/src/utils/validators.ts
@@ -1,0 +1,19 @@
+import type { SymbolId } from '@tradeforge/core';
+import { SUPPORTED_SYMBOLS } from '../constants.js';
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function assertDate(input: string): string {
+  if (!DATE_RE.test(input)) {
+    throw new Error(`date must be in format YYYY-MM-DD; received: ${input}`);
+  }
+  return input;
+}
+
+export function assertSymbol(symbol: SymbolId): SymbolId {
+  const normalized = symbol.toUpperCase() as SymbolId;
+  if (!SUPPORTED_SYMBOLS.has(normalized)) {
+    throw new Error(`symbol ${symbol} is not supported`);
+  }
+  return normalized;
+}

--- a/packages/loader-binance/tests/cli.e2e.test.ts
+++ b/packages/loader-binance/tests/cli.e2e.test.ts
@@ -1,0 +1,118 @@
+import { gzipSync } from 'node:zlib';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import nock from 'nock';
+import { createCli } from '../src/cli.js';
+import { createTradeStream, createDepthStream } from '../src/streams.js';
+
+async function collect(iter, limit = Infinity) {
+  const out = [];
+  for await (const item of iter) {
+    out.push(item);
+    if (out.length >= limit) break;
+  }
+  return out;
+}
+
+describe('CLI sync command', () => {
+  const baseUrl = 'https://mock.binance.cli';
+
+  beforeAll(() => {
+    nock.disableNetConnect();
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  afterAll(() => {
+    nock.enableNetConnect();
+  });
+
+  test('downloads once and reuses cache on rerun', async () => {
+    const tradesLines = [
+      JSON.stringify({
+        timestamp: 1620000100000,
+        price: '200.0',
+        quantity: '0.3',
+        isBuyerMaker: false,
+      }),
+    ].join('\n');
+    const depthLines = [
+      JSON.stringify({
+        timestamp: 1620000100000,
+        bids: [['200', '1']],
+        asks: [['201', '1']],
+      }),
+    ].join('\n');
+    const tradesBody = gzipSync(Buffer.from(tradesLines, 'utf8'));
+    const depthBody = gzipSync(Buffer.from(depthLines, 'utf8'));
+
+    const scope = nock(baseUrl)
+      .get(
+        '/data/futures/um/daily/trades/BTCUSDT/BTCUSDT-trades-2021-05-02.json.gz',
+      )
+      .reply(200, tradesBody)
+      .get(
+        '/data/futures/um/daily/diffBookDepth/BTCUSDT/BTCUSDT-diffBookDepth-2021-05-02.json.gz',
+      )
+      .reply(200, depthBody);
+
+    const root = mkdtempSync(join(tmpdir(), 'binance-cli-'));
+
+    await createCli().parseAsync([
+      'node',
+      'cli',
+      'sync',
+      '--symbol',
+      'BTCUSDT',
+      '--date',
+      '2021-05-02',
+      '--root',
+      root,
+      '--base-url',
+      baseUrl,
+    ]);
+
+    expect(scope.isDone()).toBe(true);
+
+    await createCli().parseAsync([
+      'node',
+      'cli',
+      'sync',
+      '--symbol',
+      'BTCUSDT',
+      '--date',
+      '2021-05-02',
+      '--root',
+      root,
+      '--base-url',
+      baseUrl,
+    ]);
+
+    expect(nock.pendingMocks()).toHaveLength(0);
+
+    const trades = await collect(
+      createTradeStream({
+        symbol: 'BTCUSDT',
+        date: '2021-05-02',
+        rootDir: root,
+      }),
+      1,
+    );
+    const depth = await collect(
+      createDepthStream({
+        symbol: 'BTCUSDT',
+        date: '2021-05-02',
+        rootDir: root,
+      }),
+      1,
+    );
+
+    expect(trades[0]?.price).toBeDefined();
+    expect(depth[0]?.asks[0]?.price).toBeGreaterThan(0);
+
+    rmSync(root, { recursive: true, force: true });
+  });
+});

--- a/packages/loader-binance/tests/depth.parser.test.ts
+++ b/packages/loader-binance/tests/depth.parser.test.ts
@@ -1,0 +1,38 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { gzipSync } from 'node:zlib';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeFileSync, rmSync } from 'node:fs';
+import { parseDepthFile } from '../src/parse/depth.js';
+
+async function collect(iter) {
+  const out = [];
+  for await (const item of iter) out.push(item);
+  return out;
+}
+
+test('parses gzipped depth JSONL', async () => {
+  const lines = [
+    JSON.stringify({
+      timestamp: 1620000000000,
+      bids: [['100.0', '0.1']],
+      asks: [['100.1', '0.2']],
+    }),
+    JSON.stringify({
+      E: 1620000000100,
+      b: [{ price: '99.9', qty: '0.5' }],
+      a: [['100.3', '0.1']],
+    }),
+  ].join('\n');
+  const buffer = gzipSync(Buffer.from(lines, 'utf8'));
+  const file = join(tmpdir(), 'depth.json.gz');
+  writeFileSync(file, buffer);
+  // @ts-ignore branded type casting is not relevant in tests
+  const depth = await collect(
+    parseDepthFile(file, { symbol: 'BTCUSDT', date: '2021-05-01' }),
+  );
+  expect(depth).toHaveLength(2);
+  expect(depth[0]?.bids[0]?.price).toBeGreaterThan(0);
+  expect(depth[1]?.asks[0]?.qty).toBeGreaterThan(0);
+  rmSync(file);
+});

--- a/packages/loader-binance/tests/sync.integration.test.ts
+++ b/packages/loader-binance/tests/sync.integration.test.ts
@@ -1,0 +1,109 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { gzipSync } from 'node:zlib';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import nock from 'nock';
+import { syncBinanceDataset } from '../src/sync.js';
+import { createTradeStream, createDepthStream } from '../src/streams.js';
+
+async function collect(iter) {
+  const out = [];
+  for await (const item of iter) out.push(item);
+  return out;
+}
+
+describe('syncBinanceDataset', () => {
+  const baseUrl = 'https://mock.binance.test';
+
+  beforeAll(() => {
+    nock.disableNetConnect();
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  afterAll(() => {
+    nock.enableNetConnect();
+  });
+
+  test('downloads archives and parses streams', async () => {
+    const tradesLines = [
+      JSON.stringify({
+        timestamp: 1620000000000,
+        price: '100.0',
+        quantity: '0.1',
+        isBuyerMaker: false,
+      }),
+      JSON.stringify({
+        timestamp: 1620000000100,
+        price: '100.1',
+        quantity: '0.2',
+        isBuyerMaker: true,
+      }),
+    ].join('\n');
+    const depthLines = [
+      JSON.stringify({
+        timestamp: 1620000000000,
+        bids: [['100', '1']],
+        asks: [['101', '2']],
+      }),
+      JSON.stringify({
+        timestamp: 1620000000100,
+        bids: [['99', '0.5']],
+        asks: [['102', '0.25']],
+      }),
+    ].join('\n');
+    const tradesBody = gzipSync(Buffer.from(tradesLines, 'utf8'));
+    const depthBody = gzipSync(Buffer.from(depthLines, 'utf8'));
+
+    nock(baseUrl)
+      .get(
+        '/data/futures/um/daily/trades/BTCUSDT/BTCUSDT-trades-2021-05-01.json.gz',
+      )
+      .reply(200, tradesBody, { 'Content-Type': 'application/gzip' });
+    nock(baseUrl)
+      .get(
+        '/data/futures/um/daily/diffBookDepth/BTCUSDT/BTCUSDT-diffBookDepth-2021-05-01.json.gz',
+      )
+      .reply(200, depthBody, { 'Content-Type': 'application/gzip' });
+
+    const root = mkdtempSync(join(tmpdir(), 'binance-loader-'));
+
+    const report = await syncBinanceDataset({
+      symbol: 'BTCUSDT',
+      date: '2021-05-01',
+      baseUrl,
+      rootDir: root,
+    });
+
+    expect(report.items.every((item) => item.status === 'downloaded')).toBe(
+      true,
+    );
+
+    // @ts-ignore branded type casting is not relevant in tests
+    const trades = await collect(
+      createTradeStream({
+        symbol: 'BTCUSDT',
+        date: '2021-05-01',
+        rootDir: root,
+      }),
+    );
+    // @ts-ignore branded type casting is not relevant in tests
+    const depth = await collect(
+      createDepthStream({
+        symbol: 'BTCUSDT',
+        date: '2021-05-01',
+        rootDir: root,
+      }),
+    );
+
+    expect(trades).toHaveLength(2);
+    expect(depth).toHaveLength(2);
+    expect(trades[0]?.side).toBe('BUY');
+    expect(depth[0]?.bids[0]?.qty).toBeGreaterThan(0);
+
+    rmSync(root, { recursive: true, force: true });
+  });
+});

--- a/packages/loader-binance/tests/trades.parser.test.ts
+++ b/packages/loader-binance/tests/trades.parser.test.ts
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { gzipSync } from 'node:zlib';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeFileSync, rmSync } from 'node:fs';
+import { parseTradesFile } from '../src/parse/trades.js';
+
+async function collect(iter) {
+  const out = [];
+  for await (const item of iter) out.push(item);
+  return out;
+}
+
+test('parses gzipped trade JSONL', async () => {
+  const lines = [
+    JSON.stringify({
+      timestamp: 1620000000000,
+      price: '100.01',
+      quantity: '0.5',
+      isBuyerMaker: false,
+      tradeId: 1,
+    }),
+    JSON.stringify({
+      time: 1620000000100,
+      p: '100.02',
+      q: '0.25',
+      m: true,
+      id: '2',
+    }),
+  ].join('\n');
+  const buffer = gzipSync(Buffer.from(lines, 'utf8'));
+  const file = join(tmpdir(), 'trades.json.gz');
+  writeFileSync(file, buffer);
+  // @ts-ignore branded type casting is not relevant in tests
+  const trades = await collect(
+    parseTradesFile(file, { symbol: 'BTCUSDT', date: '2021-05-01' }),
+  );
+  expect(trades).toHaveLength(2);
+  expect(trades[0]?.symbol).toBe('BTCUSDT');
+  expect(trades[0]?.side).toBe('BUY');
+  expect(trades[1]?.side).toBe('SELL');
+  rmSync(file);
+});

--- a/packages/loader-binance/tsconfig.json
+++ b/packages/loader-binance/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "tests"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,12 +72,6 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@22.18.3)
 
-  examples/09-bot-skeleton:
-    dependencies:
-      '@tradeforge/validation':
-        specifier: workspace:*
-        version: link:../../packages/validation
-
   apps/cli:
     dependencies:
       '@tradeforge/core':
@@ -95,6 +89,12 @@ importers:
       fastify:
         specifier: ^4.26.2
         version: 4.29.1
+
+  examples/09-bot-skeleton:
+    dependencies:
+      '@tradeforge/validation':
+        specifier: workspace:*
+        version: link:../../packages/validation
 
   packages/core:
     dependencies:
@@ -117,6 +117,25 @@ importers:
       '@types/unzipper':
         specifier: ^0.10.11
         version: 0.10.11
+
+  packages/loader-binance:
+    dependencies:
+      '@tradeforge/core':
+        specifier: workspace:^
+        version: link:../core
+      '@tradeforge/io-binance':
+        specifier: workspace:^
+        version: link:../io-binance
+      commander:
+        specifier: ^13.1.0
+        version: 13.1.0
+      unzipper:
+        specifier: ^0.12.3
+        version: 0.12.3
+    devDependencies:
+      nock:
+        specifier: ^13.5.2
+        version: 13.5.6
 
   packages/schemas:
     devDependencies:
@@ -3239,6 +3258,12 @@ packages:
         integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==,
       }
 
+  json-stringify-safe@5.0.1:
+    resolution:
+      {
+        integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==,
+      }
+
   json5@2.2.3:
     resolution:
       {
@@ -3534,6 +3559,13 @@ packages:
       {
         integrity: sha512-9iN1ka/9zmX1ZvLV9ewJYEk9h7RyRRtqdK0woXcqohu8EWIerfPUjYJPg0ULy0UqP7cslmdGc8xKDJcojlKiaw==,
       }
+
+  nock@13.5.6:
+    resolution:
+      {
+        integrity: sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==,
+      }
+    engines: { node: '>= 10.13' }
 
   node-int64@0.4.0:
     resolution:
@@ -3927,6 +3959,13 @@ packages:
         integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==,
       }
     engines: { node: '>= 6' }
+
+  propagate@2.0.1:
+    resolution:
+      {
+        integrity: sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==,
+      }
+    engines: { node: '>= 8' }
 
   proxy-addr@2.0.7:
     resolution:
@@ -6936,6 +6975,8 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-stringify-safe@5.0.1: {}
+
   json5@2.2.3: {}
 
   jsonfile@6.2.0:
@@ -7097,6 +7138,14 @@ snapshots:
   neo-async@2.6.2: {}
 
   nested-error-stacks@2.1.1: {}
+
+  nock@13.5.6:
+    dependencies:
+      debug: 4.4.3
+      json-stringify-safe: 5.0.1
+      propagate: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   node-int64@0.4.0: {}
 
@@ -7293,6 +7342,8 @@ snapshots:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
+
+  propagate@2.0.1: {}
 
   proxy-addr@2.0.7:
     dependencies:


### PR DESCRIPTION
## Summary
- add the new @tradeforge/loader-binance workspace package with CLI sync command and streaming helpers
- support archive downloads, parsing, and dataset caching utilities plus documentation and example usage
- update Jest config and package scripts so the new package tests run under the shared ESM setup

## Testing
- `pnpm --filter @tradeforge/loader-binance run lint`
- `pnpm --filter @tradeforge/loader-binance run test`
- `pnpm run lint`
- `pnpm run test:jest --testPathPattern packages/loader-binance/tests`

------
https://chatgpt.com/codex/tasks/task_e_68ce4970fcbc832097e0c25cc4a91b02