### PR TITLE
feat: add Binance live streaming feeds

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -12,6 +12,7 @@ export default {
     '^(\\.{1,2}/.*)\\.js$': '$1',
     '^@tradeforge/core$': '<rootDir>/packages/core/src/index.ts',
     '^@tradeforge/io-binance$': '<rootDir>/packages/io-binance/src/index.ts',
+    '^@tradeforge/feed-binance$': '<rootDir>/packages/feed-binance/src/index.ts',
     '^@tradeforge/loader-binance$':
       '<rootDir>/packages/loader-binance/src/index.ts',
     '^@tradeforge/sim$': '<rootDir>/packages/sim/src/index.ts',

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "dependencies": {
     "@tradeforge/core": "workspace:*",
     "@tradeforge/io-binance": "workspace:*",
+    "@tradeforge/feed-binance": "workspace:*",
     "@tradeforge/loader-binance": "workspace:*",
     "@tradeforge/validation": "workspace:*"
   }

--- a/packages/feed-binance/package.json
+++ b/packages/feed-binance/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@tradeforge/feed-binance",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --dts --format esm --out-dir dist",
+    "clean": "rimraf dist",
+    "format": "prettier -w .",
+    "lint": "eslint . --ext .ts",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --config ../../jest.config.mjs --testPathPattern packages/feed-binance/tests",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@tradeforge/core": "workspace:^",
+    "@tradeforge/io-binance": "workspace:^",
+    "ws": "^8.16.0"
+  },
+  "devDependencies": {
+    "@types/ws": "^8.5.10"
+  }
+}

--- a/packages/feed-binance/src/asyncQueue.ts
+++ b/packages/feed-binance/src/asyncQueue.ts
@@ -1,0 +1,51 @@
+export class AsyncQueue<T> implements AsyncIterable<T> {
+  private readonly items: T[] = [];
+  private readonly resolvers: ((value: IteratorResult<T>) => void)[] = [];
+  private closed = false;
+
+  push(item: T): void {
+    if (this.closed) {
+      throw new Error('Queue closed');
+    }
+    if (this.resolvers.length > 0) {
+      const resolve = this.resolvers.shift();
+      resolve?.({ value: item, done: false });
+    } else {
+      this.items.push(item);
+    }
+  }
+
+  close(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    while (this.resolvers.length > 0) {
+      const resolve = this.resolvers.shift();
+      resolve?.({ value: undefined as never, done: true });
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return {
+      next: () => this.next(),
+      return: (value?: T) => {
+        this.close();
+        return Promise.resolve({ value: value as T, done: true });
+      },
+    };
+  }
+
+  private next(): Promise<IteratorResult<T>> {
+    if (this.items.length > 0) {
+      const value = this.items.shift()!;
+      return Promise.resolve({ value, done: false });
+    }
+    if (this.closed) {
+      return Promise.resolve({ value: undefined as never, done: true });
+    }
+    return new Promise<IteratorResult<T>>((resolve) => {
+      this.resolvers.push(resolve);
+    });
+  }
+}

--- a/packages/feed-binance/src/index.ts
+++ b/packages/feed-binance/src/index.ts
@@ -1,0 +1,8 @@
+export type {
+  Logger,
+  RetryOptions,
+  RateLimitOptions,
+  RateLimitMode,
+  WebSocketConstructor,
+} from './live.js';
+export { createLiveTradeStream, createLiveDepthStream } from './live.js';

--- a/packages/feed-binance/src/live.ts
+++ b/packages/feed-binance/src/live.ts
@@ -1,0 +1,401 @@
+import WebSocket, {
+  type ClientOptions as WebSocketClientOptions,
+  type RawData,
+} from 'ws';
+import type { DepthDiff, SymbolId, Trade } from '@tradeforge/core';
+import { normalizeTrade, normalizeDepth } from '@tradeforge/io-binance';
+import { AsyncQueue } from './asyncQueue.js';
+
+export interface Logger {
+  debug?: (msg: string) => void;
+  warn?: (msg: string) => void;
+  error?: (msg: string, err?: unknown) => void;
+}
+
+export interface RetryOptions {
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  multiplier?: number;
+  maxAttempts?: number;
+}
+
+export type RateLimitMode = 'throttle' | 'debounce';
+
+export interface RateLimitOptions {
+  mode: RateLimitMode;
+  intervalMs: number;
+}
+
+interface LiveStreamOptionsBase {
+  symbol: SymbolId;
+  url?: string;
+  retry?: RetryOptions;
+  rateLimit?: RateLimitOptions;
+  signal?: AbortSignal;
+  logger?: Logger;
+  wsOptions?: WebSocketClientOptions;
+  WebSocketCtor?: WebSocketConstructor;
+}
+
+type TradeStreamOptions = LiveStreamOptionsBase;
+type DepthStreamOptions = LiveStreamOptionsBase & {
+  depthWindow?: '100ms' | '1000ms';
+};
+
+type WebSocketLike = {
+  on(event: 'open', listener: () => void): WebSocketLike;
+  on(event: 'message', listener: (data: RawData) => void): WebSocketLike;
+  on(
+    event: 'close',
+    listener: (code: number, reason: Buffer) => void,
+  ): WebSocketLike;
+  on(event: 'error', listener: (err: Error) => void): WebSocketLike;
+  send(data: string): void;
+  close(): void;
+  readyState: number;
+};
+
+export type WebSocketConstructor = new (
+  url: string,
+  options?: WebSocketClientOptions,
+) => WebSocketLike;
+
+interface BinanceAckMessage {
+  result?: unknown;
+  id?: number;
+}
+
+interface BinanceAggTradeMessage {
+  e: 'aggTrade';
+  T: number;
+  p: string;
+  q: string;
+  a?: number;
+  m: boolean;
+  E?: number;
+  [key: string]: unknown;
+}
+
+interface BinanceDepthUpdateMessage {
+  e: 'depthUpdate';
+  E: number;
+  u?: number;
+  U?: number;
+  b?: Array<[string, string]>;
+  a?: Array<[string, string]>;
+  [key: string]: unknown;
+}
+
+interface BackoffState {
+  attempt: number;
+  timeout?: NodeJS.Timeout;
+}
+
+const DEFAULT_URL = 'wss://stream.binance.com:9443/ws';
+
+const DEFAULT_RETRY: Required<RetryOptions> = {
+  initialDelayMs: 1_000,
+  maxDelayMs: 30_000,
+  multiplier: 2,
+  maxAttempts: Number.POSITIVE_INFINITY,
+};
+
+function applyRateLimit<T>(
+  queue: AsyncQueue<T>,
+  options?: RateLimitOptions,
+): (value: T) => void {
+  if (!options) {
+    return (value: T) => queue.push(value);
+  }
+  const { intervalMs, mode } = options;
+  if (mode === 'throttle') {
+    let lastEmit: number | undefined;
+    let trailingTimer: NodeJS.Timeout | undefined;
+    let trailingValue: T | undefined;
+    return (value: T) => {
+      const now = Date.now();
+      const diff = lastEmit === undefined ? intervalMs : now - lastEmit;
+      if (lastEmit === undefined || diff >= intervalMs) {
+        lastEmit = now;
+        queue.push(value);
+        if (trailingTimer) {
+          clearTimeout(trailingTimer);
+          trailingTimer = undefined;
+          trailingValue = undefined;
+        }
+        return;
+      }
+      trailingValue = value;
+      if (trailingTimer) {
+        return;
+      }
+      const delay = Math.max(0, intervalMs - diff);
+      trailingTimer = setTimeout(() => {
+        trailingTimer = undefined;
+        lastEmit = Date.now();
+        if (trailingValue !== undefined) {
+          queue.push(trailingValue);
+          trailingValue = undefined;
+        }
+      }, delay);
+    };
+  }
+  let timer: NodeJS.Timeout | undefined;
+  return (value: T) => {
+    if (timer) {
+      clearTimeout(timer);
+    }
+    timer = setTimeout(() => {
+      queue.push(value);
+      timer = undefined;
+    }, intervalMs);
+  };
+}
+
+function computeBackoffDelay(
+  state: BackoffState,
+  options: Required<RetryOptions>,
+): number {
+  const attempt = state.attempt;
+  if (attempt <= 1) {
+    return options.initialDelayMs;
+  }
+  const delay = Math.min(
+    options.initialDelayMs * Math.pow(options.multiplier, attempt - 1),
+    options.maxDelayMs,
+  );
+  return delay;
+}
+
+function withAbort(signal: AbortSignal | undefined, fn: () => void): void {
+  if (!signal) return;
+  if (signal.aborted) {
+    fn();
+    return;
+  }
+  const handler = () => {
+    signal.removeEventListener('abort', handler);
+    fn();
+  };
+  signal.addEventListener('abort', handler);
+}
+
+function isAckMessage(value: unknown): value is BinanceAckMessage {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const maybeAck = value as Record<string, unknown>;
+  return 'result' in maybeAck && 'id' in maybeAck;
+}
+
+function createBaseStream<T, TRaw>(
+  setup: (ctx: {
+    queue: AsyncQueue<T>;
+    symbol: SymbolId;
+    emit: (value: T) => void;
+    options: LiveStreamOptionsBase;
+    logger?: Logger;
+  }) => {
+    params: string[];
+    handleMessage: (raw: TRaw) => void;
+  },
+  options: LiveStreamOptionsBase,
+): AsyncIterable<T> {
+  const queue = new AsyncQueue<T>();
+  const emit = applyRateLimit(queue, options.rateLimit);
+  const logger = options.logger;
+  const { params, handleMessage } = setup({
+    queue,
+    symbol: options.symbol,
+    emit,
+    options,
+    logger,
+  });
+  const retry = {
+    ...DEFAULT_RETRY,
+    ...options.retry,
+  } as Required<RetryOptions>;
+  const WebSocketImpl =
+    options.WebSocketCtor ?? (WebSocket as unknown as WebSocketConstructor);
+  let ws: WebSocketLike | undefined;
+  const backoff: BackoffState = { attempt: 0 };
+  let closed = false;
+
+  const cleanup = () => {
+    if (closed) return;
+    closed = true;
+    if (backoff.timeout) {
+      clearTimeout(backoff.timeout);
+      backoff.timeout = undefined;
+    }
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      try {
+        ws.close();
+      } catch (err) {
+        logger?.warn?.(`Failed to close websocket: ${(err as Error).message}`);
+      }
+    } else if (ws) {
+      try {
+        ws.close();
+      } catch (err) {
+        // ignore
+      }
+    }
+    queue.close();
+  };
+
+  withAbort(options.signal, cleanup);
+
+  const subscribe = () => {
+    if (!ws) return;
+    try {
+      ws.send(
+        JSON.stringify({
+          method: 'SUBSCRIBE',
+          params,
+          id: Date.now(),
+        }),
+      );
+    } catch (err) {
+      logger?.error?.('Failed to send subscribe', err);
+    }
+  };
+
+  const scheduleReconnect = () => {
+    if (closed) return;
+    if (backoff.timeout) {
+      return;
+    }
+    backoff.attempt += 1;
+    if (backoff.attempt > retry.maxAttempts) {
+      logger?.error?.('Max reconnect attempts reached');
+      cleanup();
+      return;
+    }
+    const delay = computeBackoffDelay(backoff, retry);
+    logger?.warn?.(`Reconnecting in ${delay}ms (attempt ${backoff.attempt})`);
+    backoff.timeout = setTimeout(() => {
+      backoff.timeout = undefined;
+      connect();
+    }, delay);
+  };
+
+  const handleClose = (code: number, reason: Buffer) => {
+    logger?.warn?.(`WebSocket closed (${code}): ${reason.toString()}`);
+    ws = undefined;
+    scheduleReconnect();
+  };
+
+  const handleError = (err: Error) => {
+    logger?.error?.('WebSocket error', err);
+  };
+
+  const handleOpen = () => {
+    logger?.debug?.('WebSocket connected');
+    backoff.attempt = 0;
+    subscribe();
+  };
+
+  const handleRawMessage = (data: RawData) => {
+    try {
+      const text = typeof data === 'string' ? data : data.toString();
+      const parsed = JSON.parse(text) as unknown;
+      if (isAckMessage(parsed)) {
+        return;
+      }
+      handleMessage(parsed as TRaw);
+    } catch (err) {
+      logger?.error?.('Failed to process message', err);
+    }
+  };
+
+  const connect = () => {
+    if (closed) return;
+    ws = new WebSocketImpl(options.url ?? DEFAULT_URL, options.wsOptions);
+    ws.on('open', handleOpen);
+    ws.on('message', handleRawMessage);
+    ws.on('close', handleClose);
+    ws.on('error', handleError);
+  };
+
+  connect();
+
+  return {
+    [Symbol.asyncIterator]() {
+      const iterator = queue[Symbol.asyncIterator]();
+      return {
+        next: () => iterator.next(),
+        return: async () => {
+          cleanup();
+          return { value: undefined as never, done: true };
+        },
+      };
+    },
+  };
+}
+
+export function createLiveTradeStream(
+  options: TradeStreamOptions,
+): AsyncIterable<Trade> {
+  return createBaseStream<Trade, BinanceAggTradeMessage>(
+    ({ symbol, emit }) => ({
+      params: [`${String(symbol).toLowerCase()}@aggTrade`],
+      handleMessage: (raw) => {
+        if (!raw || raw.e !== 'aggTrade') {
+          return;
+        }
+        const trade = normalizeTrade(
+          {
+            ...raw,
+            time: raw.T,
+            price: raw.p,
+            qty: raw.q,
+            side: raw.m ? 'SELL' : 'BUY',
+            id: raw.a,
+          },
+          {
+            symbol,
+            mapping: {
+              time: 'time',
+              price: 'price',
+              qty: 'qty',
+              side: 'side',
+              id: 'id',
+            },
+          },
+        );
+        (trade as Trade & { seq?: number }).seq = Number(
+          raw.a ?? raw.T ?? raw.E,
+        );
+        emit(trade);
+      },
+    }),
+    options,
+  );
+}
+
+export function createLiveDepthStream(
+  options: DepthStreamOptions,
+): AsyncIterable<DepthDiff> {
+  const depthWindow = options.depthWindow ?? '100ms';
+  const streamName = `${String(options.symbol).toLowerCase()}@depth@${depthWindow}`;
+  return createBaseStream<DepthDiff, BinanceDepthUpdateMessage>(
+    ({ symbol, emit }) => ({
+      params: [streamName],
+      handleMessage: (raw) => {
+        if (!raw || raw.e !== 'depthUpdate') {
+          return;
+        }
+        const diff = normalizeDepth(
+          {
+            ...raw,
+          },
+          { symbol, mapping: { time: 'E', bids: 'b', asks: 'a' } },
+        );
+        (diff as DepthDiff & { seq?: number }).seq = Number(raw.u ?? raw.U);
+        emit(diff);
+      },
+    }),
+    options,
+  );
+}

--- a/packages/feed-binance/tests/live.stream.test.ts
+++ b/packages/feed-binance/tests/live.stream.test.ts
@@ -1,0 +1,196 @@
+import type { RawData } from 'ws';
+import type { DepthDiff, Trade, SymbolId } from '@tradeforge/core';
+import {
+  createLiveTradeStream,
+  createLiveDepthStream,
+  type WebSocketConstructor,
+} from '../src/live.js';
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  public readyState = 1;
+  public sent: string[] = [];
+  private listeners: {
+    open: Array<() => void>;
+    message: Array<(data: RawData) => void>;
+    close: Array<(code: number, reason: Buffer) => void>;
+    error: Array<(err: Error) => void>;
+  } = {
+    open: [],
+    message: [],
+    close: [],
+    error: [],
+  };
+
+  constructor(public readonly url: string) {
+    MockWebSocket.instances.push(this);
+  }
+
+  on(event: 'open', listener: () => void): this;
+  on(event: 'message', listener: (data: RawData) => void): this;
+  on(event: 'close', listener: (code: number, reason: Buffer) => void): this;
+  on(event: 'error', listener: (err: Error) => void): this;
+  on(
+    event: 'open' | 'message' | 'close' | 'error',
+    listener:
+      | (() => void)
+      | ((data: RawData) => void)
+      | ((code: number, reason: Buffer) => void)
+      | ((err: Error) => void),
+  ): this {
+    switch (event) {
+      case 'open':
+        this.listeners.open.push(listener as () => void);
+        break;
+      case 'message':
+        this.listeners.message.push(listener as (data: RawData) => void);
+        break;
+      case 'close':
+        this.listeners.close.push(
+          listener as (code: number, reason: Buffer) => void,
+        );
+        break;
+      case 'error':
+        this.listeners.error.push(listener as (err: Error) => void);
+        break;
+    }
+    return this;
+  }
+
+  emitOpen(): void {
+    for (const listener of this.listeners.open) {
+      listener();
+    }
+  }
+
+  emitMessage(payload: unknown): void {
+    const data =
+      typeof payload === 'string' ? payload : JSON.stringify(payload, null, 0);
+    for (const listener of this.listeners.message) {
+      listener(Buffer.from(data));
+    }
+  }
+
+  emitClose(code = 1000, reason = ''): void {
+    this.readyState = 3;
+    for (const listener of this.listeners.close) {
+      listener(code, Buffer.from(reason));
+    }
+  }
+
+  emitError(err: Error): void {
+    for (const listener of this.listeners.error) {
+      listener(err);
+    }
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.readyState = 3;
+  }
+}
+
+describe('createLiveTradeStream', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+  });
+
+  test('normalizes aggTrade payloads', async () => {
+    const stream = createLiveTradeStream({
+      symbol: 'BTCUSDT' as SymbolId,
+      WebSocketCtor: MockWebSocket as unknown as WebSocketConstructor,
+      retry: { maxAttempts: 1 },
+    });
+    const ws = MockWebSocket.instances[0];
+    expect(ws).toBeDefined();
+    ws.emitOpen();
+    const iterator = stream[Symbol.asyncIterator]();
+    const next = iterator.next();
+    ws.emitMessage({
+      e: 'aggTrade',
+      T: 1_700_000_000_000,
+      p: '100.12',
+      q: '0.5',
+      a: 42,
+      m: true,
+    });
+    const { value } = await next;
+    expect(value.price).toBe(10012000n);
+    expect(value.qty).toBe(500000n);
+    expect(value.ts).toBe(1_700_000_000_000);
+    expect((value as Trade & { seq?: number }).seq).toBe(42);
+    await iterator.return?.();
+  });
+
+  test('applies throttle rate limiting', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(0);
+    try {
+      const stream = createLiveTradeStream({
+        symbol: 'BTCUSDT' as SymbolId,
+        WebSocketCtor: MockWebSocket as unknown as WebSocketConstructor,
+        retry: { maxAttempts: 1 },
+        rateLimit: { mode: 'throttle', intervalMs: 100 },
+      });
+      const ws = MockWebSocket.instances[0];
+      ws.emitOpen();
+      const iterator = stream[Symbol.asyncIterator]();
+
+      const first = iterator.next();
+      ws.emitMessage({ e: 'aggTrade', T: 1, p: '1', q: '1', a: 1, m: false });
+      const firstValue = (await first).value as Trade & { seq?: number };
+      expect(firstValue.seq).toBe(1);
+
+      const second = iterator.next();
+      jest.setSystemTime(10);
+      ws.emitMessage({ e: 'aggTrade', T: 2, p: '2', q: '1', a: 2, m: false });
+      jest.setSystemTime(20);
+      ws.emitMessage({ e: 'aggTrade', T: 3, p: '3', q: '1', a: 3, m: false });
+      await Promise.resolve();
+      jest.advanceTimersByTime(100);
+      const secondValue = (await second).value as Trade & { seq?: number };
+      expect(secondValue.seq).toBe(3);
+
+      await iterator.return?.();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe('createLiveDepthStream', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+  });
+
+  test('normalizes depth payloads', async () => {
+    const stream = createLiveDepthStream({
+      symbol: 'BTCUSDT' as SymbolId,
+      WebSocketCtor: MockWebSocket as unknown as WebSocketConstructor,
+      retry: { maxAttempts: 1 },
+    });
+    const ws = MockWebSocket.instances[0];
+    ws.emitOpen();
+    const iterator = stream[Symbol.asyncIterator]();
+    const next = iterator.next();
+    ws.emitMessage({
+      e: 'depthUpdate',
+      E: 1_700_000_000_500,
+      u: 100,
+      b: [['100.12', '0.5']],
+      a: [['100.13', '1.0']],
+    });
+    const { value } = await next;
+    expect(value.bids[0]?.price).toBe(10012000n);
+    expect(value.bids[0]?.qty).toBe(500000n);
+    expect(value.asks[0]?.price).toBe(10013000n);
+    expect(value.asks[0]?.qty).toBe(1_000_000n);
+    expect(value.ts).toBe(1_700_000_000_500);
+    expect((value as DepthDiff & { seq?: number }).seq).toBe(100);
+    await iterator.return?.();
+  });
+});

--- a/packages/feed-binance/tsconfig.json
+++ b/packages/feed-binance/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "tests"]
+}

--- a/packages/io-binance/src/index.ts
+++ b/packages/io-binance/src/index.ts
@@ -146,3 +146,5 @@ export type {
   SourceTag,
 } from '@tradeforge/core';
 export type { CsvOptions } from './parse/csv.js';
+export { normalizeTrade } from './normalize/trades.js';
+export { normalizeDepth } from './normalize/depth.js';


### PR DESCRIPTION
## Summary
- add the @tradeforge/feed-binance package with live Binance trade and depth streams backed by AsyncQueue
- support reconnect/backoff and optional rate limiting while reusing existing normalizers and exposing them from @tradeforge/io-binance
- configure Jest to resolve the new package and surface the feed factories through the package index

## Testing
- pnpm test --filter @tradeforge/feed-binance

------
https://chatgpt.com/codex/tasks/task_e_68e28dd77b68832096c2dbea33108c29