### PR TITLE
feat(sim): add realtime engine adapter

### DIFF
--- a/packages/sim/src/index.ts
+++ b/packages/sim/src/index.ts
@@ -1,5 +1,11 @@
 export * from './types.js';
 export { EngineImpl } from './engine.js';
+export { RealtimeOrderBook } from './realtime-orderbook.js';
+export {
+  createRealtimeEngine,
+  type RealtimeEngineAdapter,
+  type RealtimeEngineOptions,
+} from './realtime-engine.js';
 export { ConservativeGate } from './conservative-gate.js';
 export { LiquidityPlanner } from './liquidity-planner.js';
 export type { PlannedLevel, PlanResult } from './liquidity-planner.js';

--- a/packages/sim/src/realtime-engine.ts
+++ b/packages/sim/src/realtime-engine.ts
@@ -1,0 +1,372 @@
+import type {
+  AccountsService,
+  ExchangeState,
+  OrdersService,
+  PlaceOrderInput,
+} from '@tradeforge/core';
+import {
+  type Fill,
+  type Liquidity,
+  type Order,
+  type OrderId,
+  type PriceInt,
+  type QtyInt,
+  type SymbolId,
+  type TimestampMs,
+} from '@tradeforge/core';
+
+import { EngineImpl } from './engine.js';
+import { RealtimeOrderBook } from './realtime-orderbook.js';
+import type {
+  Clock,
+  ConservativePolicyConfig,
+  DepthDiff,
+  Engine,
+  LiquidityConfig,
+  RejectReason,
+  SubmitOrder,
+  Trade,
+} from './types.js';
+
+interface StreamSource<T> {
+  stream: AsyncIterable<T>;
+  close?: () => Promise<void> | void;
+}
+
+type StreamInput<T> = AsyncIterable<T> | StreamSource<T>;
+
+function normalizeStream<T>(input: StreamInput<T>): StreamSource<T> {
+  if (typeof (input as StreamSource<T>).stream === 'object') {
+    const candidate = input as StreamSource<T>;
+    if (
+      candidate.stream &&
+      typeof candidate.stream[Symbol.asyncIterator] === 'function'
+    ) {
+      return candidate;
+    }
+  }
+  return { stream: input as AsyncIterable<T> };
+}
+
+type Listener<T> = (payload: T) => void;
+
+type RealtimeEngineEventPayloads = {
+  orderAccepted: Order;
+  orderUpdated: Order;
+  orderFilled: { order: Order; fill: Fill };
+  orderCanceled: Order;
+  orderRejected: Order;
+  tradeSeen: Trade;
+};
+
+type EventName = keyof RealtimeEngineEventPayloads;
+
+class RealtimeEventBus {
+  private readonly listeners: {
+    [K in EventName]: Set<Listener<RealtimeEngineEventPayloads[K]>>;
+  } = {
+    orderAccepted: new Set(),
+    orderUpdated: new Set(),
+    orderFilled: new Set(),
+    orderCanceled: new Set(),
+    orderRejected: new Set(),
+    tradeSeen: new Set(),
+  };
+
+  on<E extends EventName>(
+    event: E,
+    listener: Listener<RealtimeEngineEventPayloads[E]>,
+  ): () => void {
+    const bucket = this.listeners[event];
+    bucket.add(listener);
+    return () => {
+      bucket.delete(listener);
+    };
+  }
+
+  emit<E extends EventName>(
+    event: E,
+    payload: RealtimeEngineEventPayloads[E],
+  ): void {
+    for (const listener of this.listeners[event]) {
+      listener(payload);
+    }
+  }
+
+  clear(): void {
+    for (const bucket of Object.values(this.listeners)) {
+      bucket.clear();
+    }
+  }
+}
+
+function toSubmitOrder(order: Order): SubmitOrder {
+  if (order.type !== 'LIMIT' && order.type !== 'MARKET') {
+    throw new Error(`Unsupported order type: ${order.type}`);
+  }
+  const qty = order.qty as unknown as bigint;
+  const submit: SubmitOrder = {
+    clientId: order.id as unknown as string,
+    type: order.type,
+    side: order.side,
+    qty,
+  };
+  if (order.type === 'LIMIT') {
+    if (order.price === undefined) {
+      throw new Error('Limit order must have price');
+    }
+    submit.price = order.price as unknown as bigint;
+  }
+  return submit;
+}
+
+function mapRejectReason(reason: RejectReason): Order['rejectReason'] {
+  switch (reason) {
+    case 'INVALID_ORDER':
+      return 'INVALID_PARAMS';
+    case 'REJECTED_BY_POLICY':
+    case 'NO_LIQUIDITY':
+      return 'UNSUPPORTED_EXECUTION';
+    default:
+      return 'INVALID_PARAMS';
+  }
+}
+
+function asTimestamp(value: number): TimestampMs {
+  return value as unknown as TimestampMs;
+}
+
+function asPrice(value: bigint): PriceInt {
+  return value as unknown as PriceInt;
+}
+
+function asQty(value: bigint): QtyInt {
+  return value as unknown as QtyInt;
+}
+
+const TAKER: Liquidity = 'TAKER';
+
+export interface RealtimeEngineOptions {
+  symbol: SymbolId;
+  state: ExchangeState;
+  accounts: AccountsService;
+  orders: OrdersService;
+  streams: {
+    depth: StreamInput<DepthDiff>;
+    trades: StreamInput<Trade>;
+  };
+  clock?: Clock;
+  policy?: ConservativePolicyConfig;
+  liquidity?: LiquidityConfig;
+}
+
+export interface RealtimeEngineAdapter {
+  readonly engine: Engine;
+  placeOrder(input: PlaceOrderInput): Order;
+  cancelOrder(orderId: OrderId): boolean;
+  on<E extends EventName>(
+    event: E,
+    listener: Listener<RealtimeEngineEventPayloads[E]>,
+  ): () => void;
+  close(): Promise<void>;
+}
+
+export function createRealtimeEngine(
+  options: RealtimeEngineOptions,
+): RealtimeEngineAdapter {
+  if (!options.state.getSymbolConfig(options.symbol)) {
+    throw new Error(`Unknown symbol: ${String(options.symbol)}`);
+  }
+  const depthSource = normalizeStream(options.streams.depth);
+  const tradeSource = normalizeStream(options.streams.trades);
+  const book = new RealtimeOrderBook();
+  const engine = new EngineImpl({
+    streams: { depth: depthSource.stream, trades: tradeSource.stream },
+    book,
+    clock: options.clock,
+    policy: options.policy,
+    liquidity: options.liquidity,
+  });
+
+  const eventBus = new RealtimeEventBus();
+  const engineToCore = new Map<string, OrderId>();
+  const coreToEngine = new Map<OrderId, string>();
+  const disposers: Array<() => void> = [];
+  let closed: Promise<void> | undefined;
+
+  function link(engineId: string, orderId: OrderId): void {
+    engineToCore.set(engineId, orderId);
+    coreToEngine.set(orderId, engineId);
+  }
+
+  function unlink(engineId: string): void {
+    const coreOrderId = engineToCore.get(engineId);
+    if (coreOrderId) {
+      coreToEngine.delete(coreOrderId);
+    }
+    engineToCore.delete(engineId);
+  }
+
+  function getCoreOrder(engineId: string): Order | undefined {
+    const orderId = engineToCore.get(engineId);
+    if (!orderId) {
+      return undefined;
+    }
+    try {
+      return options.orders.getOrder(orderId);
+    } catch {
+      return undefined;
+    }
+  }
+
+  disposers.push(
+    engine.on('orderAccepted', (view) => {
+      const order = view.clientId
+        ? options.orders.getOrder(view.clientId as unknown as OrderId)
+        : getCoreOrder(view.id);
+      if (!order) {
+        return;
+      }
+      eventBus.emit('orderAccepted', order);
+    }),
+  );
+
+  disposers.push(
+    engine.on('orderFilled', (fill) => {
+      const orderId = engineToCore.get(fill.orderId);
+      if (!orderId) {
+        return;
+      }
+      const fillPayload: Fill = {
+        ts: asTimestamp(fill.ts),
+        orderId,
+        price: asPrice(fill.price),
+        qty: asQty(fill.qty),
+        side: fill.side,
+        liquidity: TAKER,
+      };
+      const order = options.orders.applyFill(orderId, fillPayload);
+      eventBus.emit('orderFilled', { order, fill: fillPayload });
+    }),
+  );
+
+  disposers.push(
+    engine.on('orderUpdated', (view) => {
+      const orderId = engineToCore.get(view.id);
+      if (!orderId && !view.clientId) {
+        return;
+      }
+      const resolvedId = orderId ?? (view.clientId as unknown as OrderId);
+      if (!resolvedId) {
+        return;
+      }
+      if (view.status === 'FILLED') {
+        const order = options.orders.closeOrder(resolvedId, 'FILLED');
+        unlink(view.id);
+        eventBus.emit('orderUpdated', order);
+        return;
+      }
+      if (view.status === 'REJECTED') {
+        const order = options.orders.closeOrder(resolvedId, 'CANCELED');
+        order.status = 'REJECTED';
+        unlink(view.id);
+        eventBus.emit('orderUpdated', order);
+        return;
+      }
+      const order = options.orders.getOrder(resolvedId);
+      eventBus.emit('orderUpdated', order);
+    }),
+  );
+
+  disposers.push(
+    engine.on('orderCanceled', (view) => {
+      const orderId = engineToCore.get(view.id);
+      if (!orderId) {
+        return;
+      }
+      const order = options.orders.closeOrder(orderId, 'CANCELED');
+      unlink(view.id);
+      eventBus.emit('orderCanceled', order);
+      eventBus.emit('orderUpdated', order);
+    }),
+  );
+
+  disposers.push(
+    engine.on('orderRejected', (event) => {
+      const orderId = event.clientId
+        ? (event.clientId as unknown as OrderId)
+        : engineToCore.get(event.orderId);
+      if (!orderId) {
+        return;
+      }
+      const order = options.orders.getOrder(orderId);
+      order.rejectReason = mapRejectReason(event.reason);
+      order.status = 'REJECTED';
+      eventBus.emit('orderRejected', order);
+      eventBus.emit('orderUpdated', order);
+    }),
+  );
+
+  disposers.push(
+    engine.on('tradeSeen', (trade) => {
+      eventBus.emit('tradeSeen', trade);
+    }),
+  );
+
+  function placeOrder(input: PlaceOrderInput): Order {
+    if (input.symbol !== options.symbol) {
+      throw new Error('Symbol mismatch for realtime engine');
+    }
+    const order = options.orders.placeOrder(input);
+    if (order.status === 'REJECTED') {
+      eventBus.emit('orderRejected', order);
+      eventBus.emit('orderUpdated', order);
+      return order;
+    }
+    const submit = toSubmitOrder(order);
+    const engineId = engine.submitOrder(submit);
+    link(engineId, order.id);
+    return order;
+  }
+
+  function cancelOrder(orderId: OrderId): boolean {
+    const engineId = coreToEngine.get(orderId);
+    if (!engineId) {
+      return false;
+    }
+    return engine.cancelOrder(engineId);
+  }
+
+  async function close(): Promise<void> {
+    if (!closed) {
+      closed = (async () => {
+        for (const dispose of disposers.splice(0)) {
+          dispose();
+        }
+        eventBus.clear();
+        await Promise.allSettled([
+          (async () => {
+            if (depthSource.close) {
+              await depthSource.close();
+            }
+          })(),
+          (async () => {
+            if (tradeSource.close) {
+              await tradeSource.close();
+            }
+          })(),
+        ]);
+        await engine.close();
+      })();
+    }
+    return closed;
+  }
+
+  return {
+    engine,
+    placeOrder,
+    cancelOrder,
+    on: (event, listener) => eventBus.on(event, listener),
+    close,
+  };
+}

--- a/packages/sim/src/realtime-orderbook.ts
+++ b/packages/sim/src/realtime-orderbook.ts
@@ -1,0 +1,92 @@
+import type {
+  DepthDiff,
+  OrderBook,
+  OrderBookLevel,
+  OrderBookSnapshot,
+} from './types.js';
+
+type BookSideMap = Map<string, bigint>;
+
+type SortDirection = 'ASC' | 'DESC';
+
+function toKey(price: bigint): string {
+  return price.toString();
+}
+
+function applyUpdates(
+  store: BookSideMap,
+  updates: ReadonlyArray<[bigint, bigint]>,
+): void {
+  for (const [price, qty] of updates) {
+    const key = toKey(price);
+    if (qty > 0n) {
+      store.set(key, qty);
+    } else {
+      store.delete(key);
+    }
+  }
+}
+
+function collectLevels(
+  store: BookSideMap,
+  direction: SortDirection,
+  depth?: number,
+): OrderBookLevel[] {
+  if (store.size === 0) {
+    return [];
+  }
+  const entries: OrderBookLevel[] = [];
+  for (const [priceStr, qty] of store.entries()) {
+    if (qty <= 0n) {
+      continue;
+    }
+    entries.push({ price: BigInt(priceStr), qty });
+  }
+  entries.sort((a, b) => {
+    if (a.price === b.price) {
+      return 0;
+    }
+    if (direction === 'ASC') {
+      return a.price < b.price ? -1 : 1;
+    }
+    return a.price > b.price ? -1 : 1;
+  });
+  if (depth === undefined) {
+    return entries;
+  }
+  if (depth <= 0) {
+    return [];
+  }
+  return entries.slice(0, depth);
+}
+
+export class RealtimeOrderBook implements OrderBook {
+  private readonly bids: BookSideMap = new Map();
+  private readonly asks: BookSideMap = new Map();
+  private lastTs?: number;
+  private lastSeq?: number;
+
+  applyDiff(diff: DepthDiff): void {
+    this.lastTs = diff.ts;
+    this.lastSeq = diff.seq;
+    if (diff.bids.length > 0) {
+      applyUpdates(this.bids, diff.bids);
+    }
+    if (diff.asks.length > 0) {
+      applyUpdates(this.asks, diff.asks);
+    }
+  }
+
+  getSnapshot(depth?: number): OrderBookSnapshot {
+    const bids = collectLevels(this.bids, 'DESC', depth);
+    const asks = collectLevels(this.asks, 'ASC', depth);
+    const snapshot: OrderBookSnapshot = { bids, asks };
+    if (this.lastTs !== undefined) {
+      snapshot.ts = this.lastTs;
+    }
+    if (this.lastSeq !== undefined) {
+      snapshot.seq = this.lastSeq;
+    }
+    return snapshot;
+  }
+}

--- a/packages/sim/tests/realtime-engine.test.ts
+++ b/packages/sim/tests/realtime-engine.test.ts
@@ -1,0 +1,133 @@
+import {
+  createRealtimeEngine,
+  type DepthDiff,
+  type Trade,
+} from '@tradeforge/sim';
+import {
+  AccountsService,
+  ExchangeState,
+  OrdersService,
+  StaticMockOrderbook,
+  type Fill,
+  type Order,
+  type PlaceOrderInput,
+  type PriceInt,
+  type QtyInt,
+  type SymbolId,
+} from '@tradeforge/core';
+import { ManualStream, depth, flushMicrotasks, trade } from './helpers.js';
+
+describe('createRealtimeEngine adapter', () => {
+  const symbol = 'BTCUSDT' as SymbolId;
+
+  function setup() {
+    const state = new ExchangeState({
+      symbols: {
+        [symbol as unknown as string]: {
+          base: 'BTC',
+          quote: 'USDT',
+          priceScale: 0,
+          qtyScale: 0,
+        },
+      },
+      fee: { makerBps: 0, takerBps: 0 },
+      orderbook: new StaticMockOrderbook({
+        best: {
+          [symbol as unknown as string]: {
+            bestBid: 100n as PriceInt,
+            bestAsk: 100n as PriceInt,
+          },
+        },
+      }),
+    });
+    const accounts = new AccountsService(state);
+    const orders = new OrdersService(state, accounts);
+    const depthStream = new ManualStream<DepthDiff>();
+    const tradeStream = new ManualStream<Trade>();
+    const adapter = createRealtimeEngine({
+      symbol,
+      state,
+      accounts,
+      orders,
+      streams: {
+        depth: { stream: depthStream, close: () => depthStream.close() },
+        trades: { stream: tradeStream, close: () => tradeStream.close() },
+      },
+    });
+    return { adapter, accounts, orders, depthStream, tradeStream };
+  }
+
+  it('fills limit orders after qualifying trades and updates state', async () => {
+    const { adapter, accounts, orders, depthStream, tradeStream } = setup();
+    const account = accounts.createAccount();
+    accounts.deposit(account.id, 'USDT', 1_000n);
+
+    const orderInput: PlaceOrderInput = {
+      accountId: account.id,
+      symbol,
+      type: 'LIMIT',
+      side: 'BUY',
+      qty: 2n as QtyInt,
+      price: 100n as PriceInt,
+    };
+
+    const fills: Array<{ order: Order; fill: Fill }> = [];
+    const unsubscribe = adapter.on('orderFilled', (payload) => {
+      fills.push(payload);
+    });
+
+    depthStream.push(depth(1, 1, [], [[100n, 5n]]));
+    await flushMicrotasks();
+
+    const placed = adapter.placeOrder(orderInput);
+    expect(placed.status).toBe('OPEN');
+
+    tradeStream.push(trade('SELL', 100n, 2n, 2));
+    await flushMicrotasks();
+
+    const stored = orders.getOrder(placed.id);
+    expect(stored.status).toBe('FILLED');
+    expect(stored.executedQty).toBe(2n as QtyInt);
+    expect(fills).toHaveLength(1);
+    expect(fills[0].fill.qty).toBe(2n as QtyInt);
+    expect(fills[0].order.status).toBe('FILLED');
+
+    const balances = accounts.getBalancesSnapshot(account.id);
+    expect(balances.BTC?.free).toBe(2n);
+    expect(balances.USDT?.free).toBe(800n);
+    expect(balances.USDT?.locked ?? 0n).toBe(0n);
+
+    unsubscribe();
+    await adapter.close();
+  });
+
+  it('executes market sells immediately on available bids', async () => {
+    const { adapter, accounts, orders, depthStream } = setup();
+    const account = accounts.createAccount();
+    accounts.deposit(account.id, 'BTC', 5n);
+
+    depthStream.push(depth(1, 1, [[100n, 10n]], []));
+    await flushMicrotasks();
+
+    const orderInput: PlaceOrderInput = {
+      accountId: account.id,
+      symbol,
+      type: 'MARKET',
+      side: 'SELL',
+      qty: 3n as QtyInt,
+    };
+
+    const placed = adapter.placeOrder(orderInput);
+    await flushMicrotasks();
+
+    const stored = orders.getOrder(placed.id);
+    expect(stored.status).toBe('FILLED');
+    expect(stored.executedQty).toBe(3n as QtyInt);
+
+    const balances = accounts.getBalancesSnapshot(account.id);
+    expect(balances.BTC?.free).toBe(2n);
+    expect(balances.USDT?.free).toBe(300n);
+
+    await adapter.close();
+  });
+});


### PR DESCRIPTION
## Summary
- implement a realtime order book that aggregates depth diffs and exposes bounded snapshots
- wire up a realtime engine adapter that feeds EngineImpl, updates core services, and re-emits lifecycle events
- cover realtime fills for limit and market orders with adapter-focused integration tests

## Testing
- pnpm --filter @tradeforge/sim test

------
https://chatgpt.com/codex/tasks/task_e_68e295074378832085022e7e0bb313b5