### PR TITLE
Fix realtime scheduler lint issues

### DIFF
--- a/apps/svc/src/realtime.ts
+++ b/apps/svc/src/realtime.ts
@@ -1,0 +1,433 @@
+import type { FastifyBaseLogger } from 'fastify';
+import { createRealtimeEngine, RealtimeOrderBook } from '@tradeforge/sim';
+import type {
+  DepthDiff as EngineDepthDiff,
+  Trade as EngineTrade,
+} from '@tradeforge/sim';
+import type {
+  DepthDiff as CoreDepthDiff,
+  SymbolId,
+  Trade as CoreTrade,
+} from '@tradeforge/core';
+
+import {
+  recordStreamTrade,
+  setFeedHealthy,
+  setStatus,
+  updateDepthFromFeed,
+  getFeedHealth,
+} from './state.js';
+import {
+  broadcastDepthUpdate,
+  broadcastFeedHealth,
+  broadcastTradeUpdate,
+} from './wsHandlers.js';
+import type { RunConfig } from './types.js';
+import type { ServiceContext } from './server.js';
+
+interface StreamSource<T> {
+  stream: AsyncIterable<T>;
+  close?: () => Promise<void> | void;
+}
+
+type StreamDescriptor<T> = AsyncIterable<T> | StreamSource<T>;
+
+function normalizeStream<T>(input: StreamDescriptor<T>): StreamSource<T> {
+  if (
+    typeof (input as StreamSource<T>).stream === 'object' &&
+    (input as StreamSource<T>).stream &&
+    typeof (input as StreamSource<T>).stream[Symbol.asyncIterator] ===
+      'function'
+  ) {
+    return input as StreamSource<T>;
+  }
+  return { stream: input as AsyncIterable<T> };
+}
+
+export interface RealtimeFeedDescriptor {
+  symbol: string;
+  depth: StreamDescriptor<CoreDepthDiff>;
+  trades: StreamDescriptor<CoreTrade>;
+}
+
+export type RealtimeFeedFactory = (
+  config: RunConfig,
+) => Promise<RealtimeFeedDescriptor[]>;
+
+function createEmptyStream<T>(): AsyncIterable<T> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      return;
+    },
+  };
+}
+
+const defaultFactory: RealtimeFeedFactory = async (config) => {
+  return config.instruments.map((instrument) => ({
+    symbol: instrument.symbol,
+    depth: createEmptyStream<CoreDepthDiff>(),
+    trades: createEmptyStream<CoreTrade>(),
+  }));
+};
+
+let feedFactory: RealtimeFeedFactory = defaultFactory;
+
+export function setRealtimeFeedFactory(
+  factory: RealtimeFeedFactory | null,
+): void {
+  feedFactory = factory ?? defaultFactory;
+}
+
+interface WorkerHandle {
+  close(): Promise<void>;
+}
+
+function formatLevels(
+  levels: Array<{ price: bigint; qty: bigint }>,
+): Array<[string, string]> {
+  return levels.map((level) => [level.price.toString(), level.qty.toString()]);
+}
+
+function normalizeSide(side?: string): 'buy' | 'sell' | undefined {
+  if (!side) {
+    return undefined;
+  }
+  const lowered = side.toLowerCase();
+  if (lowered === 'buy' || lowered === 'sell') {
+    return lowered;
+  }
+  return undefined;
+}
+
+function toEngineDepth(diff: CoreDepthDiff): EngineDepthDiff {
+  const seq = (diff as CoreDepthDiff & { seq?: number }).seq ?? 0;
+  return {
+    ts: Number(diff.ts),
+    seq,
+    bids: diff.bids.map((level) => [
+      level.price as unknown as bigint,
+      level.qty as unknown as bigint,
+    ]),
+    asks: diff.asks.map((level) => [
+      level.price as unknown as bigint,
+      level.qty as unknown as bigint,
+    ]),
+  };
+}
+
+function toEngineTrade(trade: CoreTrade): EngineTrade {
+  const sideSource = trade.side ?? trade.aggressor;
+  const side = sideSource === 'SELL' ? 'SELL' : 'BUY';
+  return {
+    ts: Number(trade.ts),
+    price: trade.price as unknown as bigint,
+    qty: trade.qty as unknown as bigint,
+    side,
+  };
+}
+
+export interface RealtimeRunSchedulerOptions {
+  config: RunConfig;
+  services: ServiceContext;
+  logger: FastifyBaseLogger;
+  healthCheckIntervalMs?: number;
+}
+
+export class RealtimeRunScheduler {
+  private readonly config: RunConfig;
+  private readonly services: ServiceContext;
+  private readonly logger: FastifyBaseLogger;
+  private readonly healthTimeoutMs: number;
+  private workers = new Map<string, WorkerHandle>();
+  private started = false;
+  private healthTimer?: NodeJS.Timeout;
+
+  constructor(options: RealtimeRunSchedulerOptions) {
+    this.config = options.config;
+    this.services = options.services;
+    this.logger = options.logger.child({ scope: 'realtime-scheduler' });
+    const configuredTimeout = Math.max(
+      2000,
+      Math.floor((this.config.heartbeatTimeoutSec ?? 6) * 1000),
+    );
+    this.healthTimeoutMs = Math.max(
+      configuredTimeout,
+      options.healthCheckIntervalMs ?? configuredTimeout,
+    );
+  }
+
+  async start(): Promise<void> {
+    if (this.started) {
+      this.logger.warn('realtime scheduler already running');
+      return;
+    }
+    this.started = true;
+    setFeedHealthy(false);
+    broadcastFeedHealth(getFeedHealth());
+    const descriptors = await feedFactory(this.config);
+    for (const descriptor of descriptors) {
+      await this.startWorker(descriptor).catch((error) => {
+        this.logger.error(
+          { symbol: descriptor.symbol, error },
+          'failed to start realtime worker',
+        );
+      });
+    }
+    const interval = Math.max(1000, Math.floor(this.healthTimeoutMs / 2));
+    this.healthTimer = setInterval(() => {
+      this.pollHealth();
+    }, interval) as NodeJS.Timeout;
+    setStatus('running');
+  }
+
+  async stop(): Promise<void> {
+    if (!this.started) {
+      return;
+    }
+    this.started = false;
+    if (this.healthTimer) {
+      clearInterval(this.healthTimer);
+      this.healthTimer = undefined;
+    }
+    const workers = Array.from(this.workers.values());
+    this.workers.clear();
+    await Promise.allSettled(workers.map((worker) => worker.close()));
+    setFeedHealthy(false);
+    broadcastFeedHealth(getFeedHealth());
+  }
+
+  private async startWorker(descriptor: RealtimeFeedDescriptor): Promise<void> {
+    const depthSource = normalizeStream(descriptor.depth);
+    const tradesSource = normalizeStream(descriptor.trades);
+    const bookMirror = new RealtimeOrderBook();
+    const { logger } = this;
+    const handleStreamClosed = this.handleStreamClosed.bind(this);
+    const handleStreamFailure = this.handleStreamFailure.bind(this);
+    const markFeedActive = this.markFeedActive.bind(this);
+
+    const depthIterator = depthSource.stream[Symbol.asyncIterator]();
+    const tradesIterator = tradesSource.stream[Symbol.asyncIterator]();
+    let cancelled = false;
+    let depthIteratorClosed = false;
+    let tradesIteratorClosed = false;
+
+    const closeDepthIterator = async () => {
+      if (depthIteratorClosed) {
+        return;
+      }
+      depthIteratorClosed = true;
+      if (typeof depthIterator.return === 'function') {
+        try {
+          await depthIterator.return();
+        } catch (error) {
+          logger.debug(
+            { symbol: descriptor.symbol, error },
+            'depth iterator return failed',
+          );
+        }
+      }
+    };
+
+    const closeTradesIterator = async () => {
+      if (tradesIteratorClosed) {
+        return;
+      }
+      tradesIteratorClosed = true;
+      if (typeof tradesIterator.return === 'function') {
+        try {
+          await tradesIterator.return();
+        } catch (error) {
+          logger.debug(
+            { symbol: descriptor.symbol, error },
+            'trade iterator return failed',
+          );
+        }
+      }
+    };
+
+    const depthStream: AsyncIterable<EngineDepthDiff> = {
+      async *[Symbol.asyncIterator]() {
+        try {
+          while (!cancelled) {
+            const { value, done } = await depthIterator.next();
+            if (done) {
+              if (!cancelled) {
+                handleStreamClosed(descriptor.symbol, 'depth');
+              }
+              break;
+            }
+            try {
+              const diff = value as CoreDepthDiff;
+              const engineDiff = toEngineDepth(diff);
+              bookMirror.applyDiff(engineDiff);
+              const snapshot = bookMirror.getSnapshot(20);
+              const ts =
+                snapshot.ts !== undefined ? Number(snapshot.ts) : Date.now();
+              updateDepthFromFeed(descriptor.symbol, {
+                bids: formatLevels(snapshot.bids),
+                asks: formatLevels(snapshot.asks),
+                ts,
+                seq: snapshot.seq,
+              });
+              markFeedActive(ts);
+              broadcastDepthUpdate(descriptor.symbol);
+              yield engineDiff;
+            } catch (error) {
+              logger.error(
+                { symbol: descriptor.symbol, error },
+                'failed to process depth diff',
+              );
+            }
+          }
+        } catch (error) {
+          if (!cancelled) {
+            handleStreamFailure(descriptor.symbol, 'depth', error);
+            throw error;
+          }
+        } finally {
+          await closeDepthIterator();
+        }
+      },
+    };
+
+    const tradeStream: AsyncIterable<EngineTrade> = {
+      async *[Symbol.asyncIterator]() {
+        try {
+          while (!cancelled) {
+            const { value, done } = await tradesIterator.next();
+            if (done) {
+              if (!cancelled) {
+                handleStreamClosed(descriptor.symbol, 'trade');
+              }
+              break;
+            }
+            try {
+              const trade = value as CoreTrade;
+              const engineTrade = toEngineTrade(trade);
+              recordStreamTrade(descriptor.symbol, {
+                priceInt: engineTrade.price.toString(),
+                qtyInt: engineTrade.qty.toString(),
+                side: normalizeSide(trade.side ?? trade.aggressor),
+                ts: engineTrade.ts,
+              });
+              markFeedActive(engineTrade.ts);
+              broadcastTradeUpdate(descriptor.symbol);
+              yield engineTrade;
+            } catch (error) {
+              logger.error(
+                { symbol: descriptor.symbol, error },
+                'failed to process trade event',
+              );
+            }
+          }
+        } catch (error) {
+          if (!cancelled) {
+            handleStreamFailure(descriptor.symbol, 'trade', error);
+            throw error;
+          }
+        } finally {
+          await closeTradesIterator();
+        }
+      },
+    };
+
+    const adapter = createRealtimeEngine({
+      symbol: descriptor.symbol as SymbolId,
+      state: this.services.state,
+      accounts: this.services.accounts,
+      orders: this.services.orders,
+      streams: {
+        depth: depthStream,
+        trades: tradeStream,
+      },
+    });
+
+    const handle: WorkerHandle = {
+      close: async () => {
+        cancelled = true;
+        const closeTasks: Array<Promise<unknown>> = [
+          adapter.close(),
+          closeDepthIterator(),
+          closeTradesIterator(),
+        ];
+        if (depthSource.close) {
+          closeTasks.push(
+            Promise.resolve().then(
+              () => depthSource.close && depthSource.close(),
+            ),
+          );
+        }
+        if (tradesSource.close) {
+          closeTasks.push(
+            Promise.resolve().then(
+              () => tradesSource.close && tradesSource.close(),
+            ),
+          );
+        }
+        const closePromise = Promise.allSettled(closeTasks);
+        const timeoutMs = Math.min(2000, this.healthTimeoutMs);
+        await Promise.race([
+          closePromise,
+          new Promise<void>((resolve) => {
+            const timer = setTimeout(resolve, timeoutMs);
+            if (typeof timer.unref === 'function') {
+              timer.unref();
+            }
+          }),
+        ]);
+      },
+    };
+
+    this.workers.set(descriptor.symbol, handle);
+  }
+
+  private markFeedActive(_ts: number): void {
+    void _ts;
+    const prev = getFeedHealth();
+    if (!prev.healthy) {
+      setFeedHealthy(true);
+      const next = getFeedHealth();
+      broadcastFeedHealth(next);
+    } else {
+      setFeedHealthy(true);
+    }
+  }
+
+  private handleStreamFailure(
+    symbol: string,
+    stream: 'depth' | 'trade',
+    error: unknown,
+  ): void {
+    this.logger.error({ symbol, stream, error }, 'realtime stream failure');
+    const prev = getFeedHealth();
+    if (prev.healthy) {
+      setFeedHealthy(false);
+      broadcastFeedHealth(getFeedHealth());
+    }
+  }
+
+  private handleStreamClosed(symbol: string, stream: 'depth' | 'trade'): void {
+    this.logger.warn({ symbol, stream }, 'realtime stream closed');
+    const prev = getFeedHealth();
+    if (prev.healthy) {
+      setFeedHealthy(false);
+      broadcastFeedHealth(getFeedHealth());
+    }
+  }
+
+  private pollHealth(): void {
+    const status = getFeedHealth();
+    if (!status.lastUpdateTs) {
+      if (status.healthy) {
+        setFeedHealthy(false);
+        broadcastFeedHealth(getFeedHealth());
+      }
+      return;
+    }
+    const stale = Date.now() - status.lastUpdateTs > this.healthTimeoutMs;
+    if (stale && status.healthy) {
+      setFeedHealthy(false);
+      broadcastFeedHealth(getFeedHealth());
+    }
+  }
+}

--- a/apps/svc/src/types.ts
+++ b/apps/svc/src/types.ts
@@ -35,6 +35,29 @@ export interface RunStateSnapshot {
   startedAt: number | null;
   pausedAt: number | null;
   stoppedAt: number | null;
+  marketData: {
+    topOfBook: Record<string, TopOfBookEntry>;
+    lastTrades: Record<string, StreamTradeEntry>;
+    feed: FeedHealthState;
+  };
+}
+
+export interface TopOfBookEntry {
+  bestBidInt: IntString | null;
+  bestAskInt: IntString | null;
+  ts: number | null;
+}
+
+export interface StreamTradeEntry {
+  priceInt: IntString;
+  qtyInt: IntString;
+  side?: 'buy' | 'sell';
+  ts: number;
+}
+
+export interface FeedHealthState {
+  healthy: boolean;
+  lastUpdateTs: number | null;
 }
 
 export type IntString = string;

--- a/apps/svc/tests/integration.rest.test.ts
+++ b/apps/svc/tests/integration.rest.test.ts
@@ -1,5 +1,17 @@
 import type { FastifyInstance } from 'fastify';
+import type { AddressInfo } from 'node:net';
+import WebSocket from 'ws';
+import type {
+  DepthDiff,
+  PriceInt,
+  QtyInt,
+  SymbolId,
+  TimestampMs,
+  Trade,
+} from '@tradeforge/core';
+
 import { createServer } from '../src/server.js';
+import { setRealtimeFeedFactory } from '../src/realtime.js';
 
 describe('REST adapter integration', () => {
   let app: FastifyInstance;
@@ -253,6 +265,244 @@ describe('REST adapter integration', () => {
     };
     expect(body.status).toBe('OPEN');
     expect(body.rejectReason).toBeUndefined();
+  });
+});
+
+describe('Realtime scheduler integration', () => {
+  let app: FastifyInstance;
+  let address: AddressInfo;
+  let ws: WebSocket | null = null;
+
+  function makeDepthDiff(params: {
+    ts: number;
+    bids: Array<[bigint, bigint]>;
+    asks: Array<[bigint, bigint]>;
+  }): DepthDiff {
+    return {
+      ts: params.ts as TimestampMs,
+      symbol: 'BTCUSDT' as SymbolId,
+      bids: params.bids.map(([price, qty]) => ({
+        price: price as PriceInt,
+        qty: qty as QtyInt,
+      })),
+      asks: params.asks.map(([price, qty]) => ({
+        price: price as PriceInt,
+        qty: qty as QtyInt,
+      })),
+    };
+  }
+
+  function makeTrade(params: {
+    ts: number;
+    price: bigint;
+    qty: bigint;
+    side?: 'BUY' | 'SELL';
+  }): Trade {
+    return {
+      ts: params.ts as TimestampMs,
+      symbol: 'BTCUSDT' as SymbolId,
+      price: params.price as PriceInt,
+      qty: params.qty as QtyInt,
+      side: params.side,
+    };
+  }
+
+  beforeAll(async () => {
+    app = createServer({ logger: false });
+    await app.listen({ port: 0, host: '127.0.0.1' });
+    address = app.server.address() as AddressInfo;
+  });
+
+  afterEach(() => {
+    setRealtimeFeedFactory(null);
+    if (ws) {
+      try {
+        ws.close();
+      } catch {
+        // ignore
+      }
+      ws = null;
+    }
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('streams market data via REST and websocket', async () => {
+    const depthEvent = makeDepthDiff({
+      ts: Date.now(),
+      bids: [[2700000000000n, 2n]],
+      asks: [[2700100000000n, 1n]],
+    });
+    const tradeEvent = makeTrade({
+      ts: Date.now() + 5,
+      price: 2700500000000n,
+      qty: 3n,
+      side: 'BUY',
+    });
+
+    setRealtimeFeedFactory(async () => [
+      {
+        symbol: 'BTCUSDT',
+        depth: (async function* () {
+          await new Promise((resolve) => setTimeout(resolve, 20));
+          yield depthEvent;
+          while (true) {
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+          }
+        })(),
+        trades: (async function* () {
+          await new Promise((resolve) => setTimeout(resolve, 40));
+          yield tradeEvent;
+          while (true) {
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+          }
+        })(),
+      },
+    ]);
+
+    const configureRes = await app.inject({
+      method: 'POST',
+      url: '/v1/runs',
+      payload: {
+        mode: 'realtime',
+        instruments: [
+          {
+            symbol: 'BTCUSDT',
+            fees: { makerBp: 1, takerBp: 1 },
+          },
+        ],
+      },
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(configureRes.statusCode).toBe(200);
+
+    ws = new WebSocket(`ws://127.0.0.1:${address.port}/ws?role=ui`);
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('ws timeout')), 3000);
+      ws!.once('open', () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+    });
+
+    type WsMessage = {
+      type: string;
+      payload: unknown;
+    };
+
+    const received: WsMessage[] = [];
+    let depthSeen = false;
+    let tradeSeen = false;
+    let healthySeen = false;
+    const awaited = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error('event timeout')),
+        4000,
+      );
+      ws!.on('message', (raw) => {
+        const message = JSON.parse(raw.toString()) as WsMessage;
+        received.push(message);
+        if (message.type === 'depth.update') {
+          depthSeen = true;
+        }
+        if (message.type === 'market.trade') {
+          tradeSeen = true;
+        }
+        if (
+          message.type === 'feed.health' &&
+          typeof message.payload === 'object' &&
+          message.payload !== null &&
+          'healthy' in message.payload &&
+          (message.payload as { healthy?: unknown }).healthy === true
+        ) {
+          healthySeen = true;
+        }
+        if (depthSeen && tradeSeen && healthySeen) {
+          clearTimeout(timeout);
+          resolve();
+        }
+      });
+    });
+
+    const startRes = await app.inject({
+      method: 'POST',
+      url: '/v1/runs/start',
+      payload: {},
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(startRes.statusCode).toBe(200);
+
+    await awaited;
+
+    const statusRes = await app.inject({
+      method: 'GET',
+      url: '/v1/runs/status',
+    });
+    expect(statusRes.statusCode).toBe(200);
+    const status = JSON.parse(statusRes.body) as {
+      marketData: {
+        topOfBook: Record<
+          string,
+          {
+            bestBidInt: string | null;
+            bestAskInt: string | null;
+            ts: number | null;
+          }
+        >;
+        lastTrades: Record<
+          string,
+          { priceInt: string; qtyInt: string; ts: number; side?: string }
+        >;
+        feed: { healthy: boolean; lastUpdateTs: number | null };
+      };
+    };
+
+    expect(status.marketData.topOfBook['BTCUSDT']).toMatchObject({
+      bestBidInt: depthEvent.bids[0].price.toString(),
+      bestAskInt: depthEvent.asks[0].price.toString(),
+    });
+    expect(status.marketData.topOfBook['BTCUSDT'].ts).not.toBeNull();
+    expect(status.marketData.lastTrades['BTCUSDT']).toMatchObject({
+      priceInt: tradeEvent.price.toString(),
+      qtyInt: tradeEvent.qty.toString(),
+    });
+    expect(status.marketData.feed.healthy).toBe(true);
+    expect(status.marketData.feed.lastUpdateTs).not.toBeNull();
+
+    const depthMessage = received.find((msg) => msg.type === 'depth.update');
+    expect(depthMessage).toBeDefined();
+    const depthPayload =
+      depthMessage &&
+      typeof depthMessage.payload === 'object' &&
+      depthMessage.payload !== null
+        ? (depthMessage.payload as {
+            symbol: string;
+            bids: Array<[string, string]>;
+            asks: Array<[string, string]>;
+          })
+        : null;
+    expect(depthPayload).not.toBeNull();
+    expect(depthPayload!.symbol).toBe('BTCUSDT');
+    expect(depthPayload!.bids[0][0]).toBe(depthEvent.bids[0].price.toString());
+
+    const tradeMessage = received.find((msg) => msg.type === 'market.trade');
+    expect(tradeMessage).toBeDefined();
+    const tradePayload =
+      tradeMessage &&
+      typeof tradeMessage.payload === 'object' &&
+      tradeMessage.payload !== null
+        ? (tradeMessage.payload as {
+            priceInt: string;
+            qtyInt: string;
+          })
+        : null;
+    expect(tradePayload).not.toBeNull();
+    expect(tradePayload!.priceInt).toBe(tradeEvent.price.toString());
+    expect(tradePayload!.qtyInt).toBe(tradeEvent.qty.toString());
+
+    await app.inject({ method: 'POST', url: '/v1/runs/stop' });
   });
 });
 


### PR DESCRIPTION
## Summary
- bind realtime scheduler stream handlers to instance methods, removing the temporary `this` alias and marking feed health transitions explicitly
- adjust the realtime scheduler feed health helper to satisfy lint expectations
- tighten websocket integration test typing and formatting so the realtime scenario passes lint

## Testing
- pnpm lint apps/svc/src/realtime.ts apps/svc/tests/integration.rest.test.ts
- pnpm test:jest --runInBand -- apps/svc/tests/integration.rest.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e2a0a5bcbc83208f9590e4e4e9ada3